### PR TITLE
Restore VideoDebate tips, improve autoscroll + refactors

### DIFF
--- a/app/assets/assets/locales/en/videoDebate.json
+++ b/app/assets/assets/locales/en/videoDebate.json
@@ -53,5 +53,10 @@
   "loading": {
     "statements": "Loading Statements",
     "video": "Loading Video"
+  },
+  "tips": {
+    "firstStatement": "Now <1>add your first statement</1> by clicking on the <3></3> icon next to the speaker's name",
+    "firstSpeaker": "Start by adding a speaker using left column",
+    "noContentUnauthenticated": "This video hasn't been verified yet. Login / Signup to contribute!"
   }
 }

--- a/app/assets/assets/locales/fr/videoDebate.json
+++ b/app/assets/assets/locales/fr/videoDebate.json
@@ -57,5 +57,10 @@
   "loading": {
     "statements": "Chargement des textes",
     "video": "Chargement de la video"
+  },
+  "tips": {
+    "firstStatement": "Maintenant <1>ajoutez votre première citation</1> en cliquant sur l'icone <3></3> à côté du nom de l'intervenant",
+    "firstSpeaker": "Commencez par ajouter un intervenant en utilisant la colonne de gauche",
+    "noContentUnauthenticated": "Cette vidéo n'a pas encore été vérifiée. Connectez-vous pour contribuer!"
   }
 }

--- a/app/components/Comments/CommentForm.jsx
+++ b/app/components/Comments/CommentForm.jsx
@@ -25,7 +25,7 @@ const validate = ({ source, text }) => {
   if (url && !hasValidUrl)
     errors['source'] = {url: 'Invalid URL'}
   if (!hasValidUrl && !text)
-    errors['text'] = 'You must either set a comment or a source'
+    errors['text'] = true
   else if (text)
     validateLength(errors, 'text', text, COMMENT_LENGTH, "Comment")
   return errors

--- a/app/components/Statements/StatementForm.jsx
+++ b/app/components/Statements/StatementForm.jsx
@@ -83,7 +83,7 @@ export class StatementForm extends React.PureComponent {
     if (!statement.speaker_id)
       statement.speaker_id = null
     this.props.handleConfirm(statement).then(handleFormEffectResponse({
-      onSuccess: (st) => this.props.setScrollTo(st)
+      onSuccess: ({id}) => this.props.setScrollTo({id, __forceAutoScroll: true})
     }))
   }
 

--- a/app/components/Statements/StatementsList.jsx
+++ b/app/components/Statements/StatementsList.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { connect } from "react-redux"
+import { translate } from 'react-i18next'
+import { withRouter } from 'react-router'
+
+import { StatementForm } from './StatementForm'
+import { Statement } from './Statement'
+import { closeStatementForm, setScrollTo } from '../../state/video_debate/statements/reducer'
+import { postStatement } from '../../state/video_debate/statements/effects'
+import { statementFormValueSelector } from '../../state/video_debate/statements/selectors'
+
+
+
+@connect(state => ({
+  statements: state.VideoDebate.statements.data,
+  statementFormSpeakerId: statementFormValueSelector(state, 'speaker_id')
+}), {closeStatementForm, postStatement, setScrollTo})
+@translate('videoDebate')
+@withRouter
+export default class StatementsList extends React.PureComponent {
+  componentDidMount() {
+    if (this.props.location.query.statement) {
+      this.props.setScrollTo({id: parseInt(this.props.location.query.statement), __forceAutoScroll: true})
+    }
+  }
+
+  render() {
+    const {statementFormSpeakerId, statements} = this.props
+    return (
+      <div className="statements-list">
+        {statementFormSpeakerId !== undefined &&
+        <StatementForm
+          initialValues={{speaker_id: statementFormSpeakerId}}
+          enableReinitialize={true}
+          keepDirtyOnReinitialize={true}
+          handleAbort={() => this.props.closeStatementForm()}
+          handleConfirm={s => this.props.postStatement(s).then(
+            e => {if (!e.error) this.props.closeStatementForm(); return e;}
+          )}/>
+        }
+        {statements.map(statement => <Statement key={statement.id} statement={statement}/>)}
+      </div>
+    )
+  }
+}

--- a/app/components/VideoDebate/ActionBubbleMenu.jsx
+++ b/app/components/VideoDebate/ActionBubbleMenu.jsx
@@ -29,7 +29,9 @@ export default class ActionBubbleMenu extends React.PureComponent {
 
   addStatement() {
     this.props.changeStatementFormSpeaker({id: 0})
-    document.querySelector('.statements-list').scrollIntoView()
+    const domElement = document.querySelector('.statements-list')
+    if (domElement)
+      domElement.scrollIntoView()
   }
 
   activate() {

--- a/app/components/VideoDebate/ColumnDebate.jsx
+++ b/app/components/VideoDebate/ColumnDebate.jsx
@@ -1,0 +1,68 @@
+import React from "react"
+import { connect } from "react-redux"
+import { Trans, translate } from 'react-i18next'
+
+import History from "./History"
+import ActionBubbleMenu from './ActionBubbleMenu'
+import StatementsList from '../Statements/StatementsList'
+import { LoadingFrame } from '../Utils/LoadingFrame'
+import { hasStatementForm } from '../../state/video_debate/statements/selectors'
+import { Icon } from '../Utils/Icon'
+import { isAuthenticated } from '../../state/users/current_user/selectors'
+
+
+@connect(state => ({
+  isLoading: state.VideoDebate.video.isLoading || state.VideoDebate.statements.isLoading,
+  hasStatements: state.VideoDebate.statements.data.size !== 0,
+  hasSpeakers: state.VideoDebate.video.data.speakers.size !== 0,
+  hasStatementForm: hasStatementForm(state),
+  authenticated: isAuthenticated(state)
+}))
+@translate('videoDebate')
+export class ColumnDebate extends React.PureComponent {
+  render() {
+    return <div id="col-debate" className="column">{this.renderContent()}</div>
+  }
+
+  renderContent() {
+    const { isLoading, view, videoId, hasStatements } = this.props
+
+    if (view === 'history')
+      return <History videoId={ videoId }/>
+    else if (view === 'debate') {
+      if (isLoading)
+        return <LoadingFrame title={this.props.t('loading.statements')}/>
+      return (
+        <div className="statements-list-container">
+          {!hasStatements && !this.props.hasStatementForm ? this.renderHelp() : <StatementsList/>}
+          <ActionBubbleMenu/>
+        </div>
+      )
+    }
+  }
+
+  renderHelp() {
+    const { hasSpeakers, authenticated, t } = this.props
+    let helpMessage = ''
+    if (!authenticated)
+      helpMessage = t('tips.noContentUnauthenticated')
+    else if (!hasSpeakers)
+      helpMessage = t('tips.firstSpeaker')
+    else
+      helpMessage = (
+        <Trans i18nKey="tips.firstStatement" parent="span">
+          [Now] <strong>[add]</strong> [click] <Icon name="commenting-o"/>&nbsp;[icon]
+        </Trans>
+      )
+
+    return (
+      <div className="video-debate-help">
+        <article className="message is-info">
+          <div className="message-body">
+            <Icon name="info-circle"/>&nbsp;{helpMessage}
+          </div>
+        </article>
+      </div>
+    )
+  }
+}

--- a/app/components/VideoDebate/ColumnVideo.jsx
+++ b/app/components/VideoDebate/ColumnVideo.jsx
@@ -1,0 +1,59 @@
+import React from "react"
+import { connect } from "react-redux"
+import classNames from "classnames"
+import { translate } from 'react-i18next'
+
+import { AddSpeakerForm, SpeakerPreview } from "../Speakers"
+import { VideoPlayer } from "../Videos"
+import { LoadingFrame, Icon } from "../Utils"
+import { Link } from 'react-router'
+import { isAuthenticated } from "../../state/users/current_user/selectors"
+
+
+@connect(state => ({
+  video: state.VideoDebate.video.data,
+  isLoading: state.VideoDebate.video.isLoading,
+  authenticated: isAuthenticated(state),
+}))
+@translate('videoDebate')
+export class ColumnVideo extends React.PureComponent {
+  render() {
+    if (this.props.isLoading)
+      return <LoadingFrame title={this.props.t('loading.video')}/>
+
+    const { video, authenticated, view, t } = this.props
+    const { url, title, speakers } = video
+    return (
+      <div id="col-video" className="column is-4">
+        <VideoPlayer url={url}/>
+        <h3 className="title is-4">{title}</h3>
+        <div className="tabs is-toggle is-fullwidth">
+          <ul>
+            <li className={classNames({'is-active': view === "debate"})}>
+              <Link to={`/videos/${video.id}`}>
+                <Icon size="small" name="comments-o"/>
+                <span>{ t('debate') }</span>
+              </Link>
+            </li>
+            <li className={classNames({'is-active': view === "history"})}>
+              <Link to={`/videos/${video.id}/history`}>
+                <Icon size="small" name="history"/>
+                <span>{ t('history') }</span>
+              </Link>
+            </li>
+          </ul>
+        </div>
+        {authenticated &&
+        <div className="actions">
+          <AddSpeakerForm/>
+        </div>
+        }
+        <div className="speakers-list">
+          {speakers.map(speaker =>
+            <SpeakerPreview key={speaker.id} speaker={speaker}/>
+          )}
+        </div>
+      </div>
+    )
+  }
+}

--- a/app/components/VideoDebate/index.jsx
+++ b/app/components/VideoDebate/index.jsx
@@ -1,48 +1,26 @@
 import React from "react"
 import { connect } from "react-redux"
-import classNames from "classnames"
-import { formValueSelector, reset } from 'redux-form'
 import { translate } from 'react-i18next'
 
-import { StatementForm, Statement } from "../Statements"
-import { AddSpeakerForm, SpeakerPreview } from "../Speakers"
-import { VideoPlayer } from "../Videos"
-import { LoadingFrame, ErrorView, Icon } from "../Utils"
-import {Link, withRouter} from 'react-router'
-import History from "./History"
+import { ErrorView } from "../Utils"
 import { isAuthenticated } from "../../state/users/current_user/selectors"
 import { joinCommentsChannel, leaveCommentsChannel } from '../../state/video_debate/comments/effects'
-import {
-  joinStatementsChannel, leaveStatementsChannel, postStatement
-} from '../../state/video_debate/statements/effects'
-import { setPosition, reset as resetVideo } from '../../state/video_debate/video/reducer'
+import { joinStatementsChannel, leaveStatementsChannel } from '../../state/video_debate/statements/effects'
 import { joinVideoDebateChannel, leaveVideoDebateChannel } from '../../state/video_debate/effects'
-import {closeStatementForm, setScrollTo} from '../../state/video_debate/statements/reducer'
-import ActionBubbleMenu from './ActionBubbleMenu'
-
-
-// TODO Refactor this giant octopus. Video column can be split in a different component
-
-const statementFormSelector = formValueSelector('StatementForm')
+import { resetVideoDebate } from '../../state/video_debate/actions'
+import { ColumnVideo } from './ColumnVideo'
+import { ColumnDebate } from './ColumnDebate'
 
 
 @connect(state => ({
-  video: state.VideoDebate.video.data,
-  isLoadingVideo: state.VideoDebate.video.isLoading,
   videoErrors: state.VideoDebate.video.errors,
-  statements: state.VideoDebate.statements.data,
-  isLoadingStatements: state.VideoDebate.statements.isLoading,
-  playback: state.VideoDebate.playback,
-  statementFormSpeakerId: statementFormSelector(state, 'speaker_id'),
-  currentView: state.VideoDebate.currentView,
-  authenticated: isAuthenticated(state)
+  authenticated: isAuthenticated(state),
 }), {
-  joinCommentsChannel, leaveCommentsChannel, joinStatementsChannel, leaveStatementsChannel,
-  joinVideoDebateChannel, leaveVideoDebateChannel,
-  resetVideo, postStatement, setPosition, reset, closeStatementForm, setScrollTo
+  joinVideoDebateChannel, joinCommentsChannel, joinStatementsChannel,
+  leaveCommentsChannel, leaveStatementsChannel, leaveVideoDebateChannel,
+  resetVideoDebate
 })
 @translate('videoDebate')
-@withRouter
 export class VideoDebate extends React.PureComponent {
   componentDidMount() {
     // Join channels
@@ -52,140 +30,22 @@ export class VideoDebate extends React.PureComponent {
       this.props.joinStatementsChannel(videoId)
       this.props.joinCommentsChannel(videoId)
     }
-
-    if (this.props.location.query.statement) {
-      this.props.setScrollTo({id: parseInt(this.props.location.query.statement)})
-    }
   }
 
   componentWillUnmount() {
     this.props.leaveCommentsChannel()
     this.props.leaveStatementsChannel()
     this.props.leaveVideoDebateChannel()
-    this.props.resetVideo()
-  }
-
-  renderStatements() {
-    if (this.props.isLoadingStatements) return (
-      <div className="statements-list">
-        <LoadingFrame title={this.props.t('loading.statements')}/>
-      </div>
-    )
-    const {statementFormSpeakerId, statements} = this.props
-    return (
-      <div className="statements-list">
-        <ActionBubbleMenu/>
-        {statementFormSpeakerId !== undefined &&
-          <StatementForm
-            initialValues={{speaker_id: statementFormSpeakerId}}
-            enableReinitialize={true}
-            keepDirtyOnReinitialize={true}
-            handleAbort={() => this.props.closeStatementForm()}
-            handleConfirm={s => this.props.postStatement(s).then(
-              e => {if (!e.error) this.props.closeStatementForm(); return e;}
-            )}/>
-        }
-        {statements.map((statement) => (
-          <Statement key={statement.id} statement={statement}/>
-        ))}
-      </div>
-    )
-  }
-
-  renderColVideo() {
-    if (this.props.isLoadingVideo)
-      return <LoadingFrame title={this.props.t('loading.video')}/>
-    const { video, authenticated, route, t } = this.props
-    const { url, title, speakers } = video
-
-    return (
-      <div id="col-video" className="column is-4">
-        <VideoPlayer url={url}/>
-        <h3 className="title is-4">{title}</h3>
-          <div className="tabs is-toggle is-fullwidth">
-            <ul>
-              <li className={classNames({'is-active': route.view === "debate"})}>
-                <Link to={`/videos/${video.id}`}>
-                  <Icon size="small" name="comments-o"/>
-                  <span>{ t('debate') }</span>
-                </Link>
-              </li>
-              <li className={classNames({'is-active': route.view === "history"})}>
-                <Link to={`/videos/${video.id}/history`}>
-                  <Icon size="small" name="history"/>
-                  <span>{ t('history') }</span>
-                </Link>
-              </li>
-            </ul>
-          </div>
-          {authenticated &&
-          <div className="actions">
-            <AddSpeakerForm/>
-          </div>
-          }
-          <div className="speakers-list">
-            {speakers.map((speaker) => (
-              <SpeakerPreview key={speaker.id} speaker={speaker}/>
-            ))}
-          </div>
-      </div>
-    )
-  }
-
-  renderHelp() {
-    const {video: {speakers}, authenticated} = this.props
-    if (authenticated)
-      var helpMessage = speakers.size === 0 ?
-        (
-          <span>
-            Start by <strong>adding the first speaker</strong>
-          </span>
-        ) :
-        (
-          <span>
-            Now <strong>add your first statement</strong> by clicking on the <Icon name="commenting-o"/>
-          &nbsp;icon next to the speaker's name
-          </span>
-        )
-    else
-      var helpMessage = "This video doesn't have any statement yet"
-    return (
-      <div className="video-debate-help">
-        <article className="message is-info">
-          <div className="message-body">
-            <Icon name="info-circle"/>&nbsp;{helpMessage}
-          </div>
-        </article>
-      </div>
-    )
+    this.props.resetVideoDebate()
   }
 
   render() {
-    const { statements, statementFormSpeaker, isLoadingVideo } = this.props
-    const { isLoadingStatements, videoErrors, params, route } = this.props
-    if (videoErrors) return <ErrorView error={videoErrors}/>
-
-    if (!isLoadingVideo && !isLoadingStatements && statements.size === 0 &&
-      statementFormSpeaker === null && params.videoId)
-        var colStatementsContent = this.renderHelp()
-    else if (params.videoId)
-      var colStatementsContent = this.renderStatements()
-    else
-      return <ErrorView error="not_found"/>
-
+    if (this.props.videoErrors)
+      return <ErrorView error={this.props.videoErrors}/>
     return (
       <div id="video-show" className="columns is-gapless">
-        {this.renderColVideo()}
-        <div id="col-debate" className="column">
-          {route.view === "debate" &&
-            <div className="statements-list-container">
-              {colStatementsContent}
-            </div>
-          }
-          {route.view === "history" &&
-            <History videoId={ this.props.params.videoId }/>
-          }
-        </div>
+        <ColumnVideo view={this.props.route.view}/>
+        <ColumnDebate view={this.props.route.view} videoId={this.props.params.videoId}/>
       </div>
     )
   }

--- a/app/i18n.js
+++ b/app/i18n.js
@@ -33,8 +33,8 @@ i18n
       prefix: '_translations',
       expirationTime: 48*60*60*1000, // 48h
       versions: {
-        en: "0.7.0",
-        fr: "0.7.0"
+        en: "0.7.1",
+        fr: "0.7.1"
       }
     },
     detection: {

--- a/app/state/index.js
+++ b/app/state/index.js
@@ -1,8 +1,12 @@
 import { createStore, combineReducers, applyMiddleware, compose } from "redux"
 import { reducer as formReducer } from 'redux-form'
+import Immutable from 'immutable'
 import promiseMiddleware from 'redux-promise'
 import thunk from 'redux-thunk'
 
+import { JS_ENV } from '../config.jsenv'
+
+// Reducers
 import FlashesReducer from './flashes/reducer'
 import VideoDebateReducer from './video_debate/reducer'
 import CurrentUserReducer from './users/current_user/reducer'
@@ -30,12 +34,17 @@ const reducers = combineReducers({
 // Declare middlewares
 const middlewares = [thunk, promiseMiddleware]
 
+// If running in dev and browser has redux devtools extension activated, use it
+const getComposer = () => {
+  if (JS_ENV === 'prod' || !window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__)
+    return compose
+  return window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+    serialize: {immutable: Immutable},
+    shouldCatchErrors: true
+  })
+}
 
 // Build store
-const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
-const store = createStore(
-  reducers,
-  composeEnhancers(applyMiddleware(...middlewares))
-)
+const store = createStore(reducers, getComposer()(applyMiddleware(...middlewares)))
 
 export default store

--- a/app/state/video_debate/actions.js
+++ b/app/state/video_debate/actions.js
@@ -1,0 +1,5 @@
+import { createAction } from 'redux-actions'
+
+
+// Actions common to all VideoDebate reducers
+export const resetVideoDebate = createAction('VIDEO_DEBATE/RESET')

--- a/app/state/video_debate/comments/reducer.js
+++ b/app/state/video_debate/comments/reducer.js
@@ -4,6 +4,7 @@ import isAfter from 'date-fns/is_after'
 
 import Comment from "./record"
 import parseDateTime from '../../../lib/parseDateTime'
+import { resetVideoDebate } from '../actions'
 
 
 export const addFlag = createAction('COMMENTS/ADD_FLAG')
@@ -108,7 +109,8 @@ const CommentsReducer = handleActions({
         state = state.updateIn(['replies', commentId], oldList => mergeCommentsList(oldList, newComments))
     }
     return state
-  }
+  },
+  [resetVideoDebate]: () => INITIAL_STATE()
 }, INITIAL_STATE())
 
 // Sort comments by score. More recents come firsts if same score

--- a/app/state/video_debate/history/reducer.js
+++ b/app/state/video_debate/history/reducer.js
@@ -1,5 +1,5 @@
 import { Record, List, Map } from 'immutable'
-import { createAction, handleActions } from 'redux-actions'
+import { createAction, handleActions, combineActions } from 'redux-actions'
 import { diffWordsWithSpace } from 'diff'
 
 import parseDateTime from '../../../lib/parseDateTime'
@@ -8,6 +8,7 @@ import UserAction from "../../user_actions/record"
 import Statement from '../statements/record'
 import Speaker from '../speakers/record'
 import {ENTITY_SPEAKER, ENTITY_STATEMENT} from '../../../constants'
+import { resetVideoDebate } from '../actions'
 
 export const setLoading = createAction('VIDEO_DEBATE_HISTORY/SET_LOADING')
 export const reset = createAction('VIDEO_DEBATE_HISTORY/RESET')
@@ -79,7 +80,7 @@ const VideoDebateHistoryReducer = handleActions({
     })
     return state.setIn(['diffs', payload.id], diff)
   },
-  [reset]: () => INITIAL_STATE()
+  [combineActions(reset, resetVideoDebate)]: () => INITIAL_STATE()
 }, INITIAL_STATE())
 export default VideoDebateHistoryReducer
 

--- a/app/state/video_debate/statements/reducer.js
+++ b/app/state/video_debate/statements/reducer.js
@@ -3,6 +3,7 @@ import { combineActions, createAction, handleActions } from 'redux-actions'
 import { change, destroy } from 'redux-form'
 
 import Statement from './record'
+import { resetVideoDebate } from '../actions'
 
 
 export const fetchStatements = createAction('STATEMENTS/FETCH')
@@ -77,7 +78,8 @@ const StatementsReducer = handleActions({
   },
   [setScrollTo]: (state, {payload}) => state.set('scrollTo', payload),
   [combineActions(incrementFormCount, decrementFormCount)]: (state, {payload}) =>
-    state.set('formsCount', state.formsCount + payload)
+    state.set('formsCount', state.formsCount + payload),
+  [resetVideoDebate]: () => INITIAL_STATE()
 }, INITIAL_STATE())
 
 function getInsertPosition(data, newStatement) {

--- a/app/state/video_debate/statements/selectors.js
+++ b/app/state/video_debate/statements/selectors.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect'
 import createCachedSelector from 're-reselect'
+import { formValueSelector } from 'redux-form'
 
 import { getVideoDebateSpeakers } from '../../video_debate/selectors'
 import { getStatementApprovingFacts, getStatementRefutingFacts } from "../comments/selectors"
@@ -55,3 +56,6 @@ export const isStatementFocused = createSelector(
   (focusedStatementId, statementId) => focusedStatementId === statementId
 )
 
+export const statementFormValueSelector = formValueSelector('StatementForm')
+
+export const hasStatementForm = state => statementFormValueSelector(state, 'speaker_id') !== undefined

--- a/app/state/video_debate/video/reducer.js
+++ b/app/state/video_debate/video/reducer.js
@@ -3,6 +3,7 @@ import { Record, List } from 'immutable'
 
 import Video from '../../videos/record'
 import Speaker from '../speakers/record'
+import { resetVideoDebate } from '../actions'
 
 
 export const fetchAll = createAction('VIDEO/FETCH_ALL')
@@ -10,7 +11,6 @@ export const setLoading = createAction('VIDEO/SET_LOADING')
 export const addSpeaker = createAction('VIDEO/ADD_SPEAKER')
 export const removeSpeaker = createAction('VIDEO/REMOVE_SPEAKER')
 export const updateSpeaker = createAction('VIDEO/UPDATE_SPEAKER')
-export const reset = createAction('VIDEO/RESET')
 
 export const setPosition = createAction('PLAYBACK/SET_POSITION')
 export const forcePosition = createAction('PLAYBACK/FORCE_POSITION')
@@ -56,7 +56,7 @@ const VideoReducer = handleActions({
         .updateIn(['data', 'speakers'], speakers => sortSpeakers(speakers))
     return state
   },
-  [reset]: state => INITIAL_STATE(),
+  [resetVideoDebate]: state => INITIAL_STATE(),
   [setPosition]: (state, {payload}) =>
     state.setIn(['playback', 'position'], Math.trunc(payload)),
   [forcePosition]: (state, {payload}) =>


### PR DESCRIPTION
# VideoDebate 

## Help / tips

@NGambini our conversation reminded me that tips to guide new users through the debate interface used to exist, somehow recent changes made them disappear without me noticing. They have been restored and translated (en/fr):

* Message without speakers
![Message without speakers](https://user-images.githubusercontent.com/1556356/32403717-49198a78-c195-11e7-9ddb-bcd7226bad74.jpg)

* Message with speakers
![Message with speakers](https://user-images.githubusercontent.com/1556356/32403705-2be9aabe-c195-11e7-9a82-88153341173a.jpg)

## Refactors + improvements

* `<VideoDebate/>` component was way too huge and has been split into `LeftColumn`, `RightColumn` and `StatementsList`
* Reset full VideoDebate state when unmounting


# Autoscroll

* Refactored code
* Some tricky cases are now handled (autoscroll disabled + scroll on recently added statement)

# Misc

* Disable redux dev tools extension if running on prod
