### PR TITLE
Sources rich medias improvements

### DIFF
--- a/app/components/Comments/Source.jsx
+++ b/app/components/Comments/Source.jsx
@@ -1,40 +1,37 @@
 import React from "react"
 import ReactPlayer from "react-player"
 import upperCase from "voca/upper_case"
-import lowerCase from "voca/lower_case"
+import { dailymotionRegex, soundcloudRegex, youtubeRegex } from '../../lib/url_utils'
 
-// const truncateUrl = (url, maxLength) => {
-//   if (url.length >= maxLength) {
-//     url = trimRight(url, '/')
-//     const regex = /(http:\/\/|https:\/\/)?([-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6})\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/ig
-//     const urlParts = regex.exec(url)
-//     if (urlParts) {
-//       const afterSlash = urlParts[3].split('/')
-//       url = `${urlParts[2]}/.../${afterSlash[afterSlash.length - 1]}`
-//     }
-//   }
-//   return url.replace(/https?:\/\//, "")
-// }
 
-const supportedPlayers = ['youtube', 'dailymotion', 'twitch', 'soundcloud', 'streamable', 'vidme', 'vimeo', 'wistia']
+const supportedPlayerUrls = [youtubeRegex, dailymotionRegex, soundcloudRegex]
 
-const getHostName = url =>
-  upperCase(url.replace(/https?:\/\//, "").replace(/\/.*/g, ""))
 
-const isPlayer = site_name => supportedPlayers.includes(lowerCase(site_name))
+/**
+ * Returns displayable, uppercase host name
+ * ex: https://www.toto.fr/titi/page.lol => TOTO.FR
+ */
+const getDisplayableHostname = url =>
+  upperCase(url.replace(/^https?:\/\//i, "").replace(/^www\./i, "").replace(/\/.*/g, ""))
+
+/**
+ * Check if we want to render medias from that website into players using `supportedPlayerUrls`
+ */
+const isPlayer = url => {
+  for (let playerRegex of supportedPlayerUrls) {
+    if (playerRegex.test(url))
+      return true
+  }
+  return false
+}
 
 export const Source = ({ source: { url, title, site_name }, withoutPlayer }) => {
-  if (isPlayer(site_name) && !withoutPlayer) {
-    return (<ReactPlayer width='100%' url={url} config={{
-      youtube: { preload: false },
-      facebook: { preload: false },
-      dailymotion: { preload: false },
-      soundcloud: { preload: false }
-    }} />)
+  if (!withoutPlayer && isPlayer(url)) {
+    return <ReactPlayer className="video" controls={true} height={180} width={320} url={url}/>
   } else {
     return <a href={url} target="_BLANK" className="fact-source">
       <span className="site-name">
-        {upperCase(site_name) || getHostName(url)}
+        {upperCase(site_name) || getDisplayableHostname(url)}
       </span>
       <span className="article-title">{title}</span>
     </a>

--- a/app/components/Videos/AddVideoForm.jsx
+++ b/app/components/Videos/AddVideoForm.jsx
@@ -1,10 +1,10 @@
 import React from "react"
 import { withRouter } from "react-router"
 import { Field, reduxForm } from 'redux-form'
-import youtubeRegex from "youtube-regex"
 import { connect } from 'react-redux'
 import trim from 'voca/trim'
 
+import { youtubeRegex } from '../../lib/url_utils'
 import { DummyVideoPlayer } from "../Videos"
 import { FieldWithButton } from "../FormUtils"
 import { LoadingFrame } from '../Utils/LoadingFrame'
@@ -13,7 +13,7 @@ import { isAuthenticated } from '../../state/users/current_user/selectors'
 
 
 const validate = ({ url }) => {
-  if (!youtubeRegex().test(url))
+  if (!youtubeRegex.test(url))
     return {url: "Invalid URL. Only youtube videos are currently supported"}
   return {}
 }

--- a/app/components/Videos/DummyVideoPlayer.jsx
+++ b/app/components/Videos/DummyVideoPlayer.jsx
@@ -26,12 +26,8 @@ export class DummyVideoPlayer extends React.PureComponent {
 
   render() {
     const { url } = this.props
-    const embedUrl = url.replace("http://", "https://")
-                        .replace("youtube.com", "youtube-nocookie.com") // Use Youtube privacy enhancer
-                        .replace("/watch?v=", "/embed/")
-                        .replace(/&.*/, "") // Remove useless get params
     const {playback, dispatch, onProgress, position, forcedPosition, ...iframeProps} = this.props
-    if (!embedUrl)
+    if (!url)
       return (<div className="video"><div/></div>)
     return (
       <ReactPlayer className="video"

--- a/app/lib/url_utils.js
+++ b/app/lib/url_utils.js
@@ -1,0 +1,8 @@
+export const youtubeRegex =
+  /(?:youtube\.com\/\S*(?:(?:\/e(?:mbed))?\/|watch\/?\?(?:\S*?&?v\=))|youtu\.be\/)([a-zA-Z0-9_-]{6,11})/
+
+export const dailymotionRegex =
+  /^.+dailymotion.com\/(video|hub)\/([^_]+)[^#]*(#video=([^_&]+))?/
+
+export const soundcloudRegex =
+  /^https?:\/\/(soundcloud.com|snd.sc)\/([a-z0-9-_]+\/[a-z0-9-_]+)$/

--- a/app/styles/_components/VideoDebate/video_debate.sass
+++ b/app/styles/_components/VideoDebate/video_debate.sass
@@ -4,7 +4,7 @@
   max-width: 100%
   min-width: 370px
 
-  &.form .control
+  &.form .control /* TODO Is this used ? */
     padding: 5px
 
   &> .title
@@ -20,6 +20,20 @@
         border-left: none
       &:last-child
         border-right: none
+
+  .video > div
+    @include animate(fadeIn, 1s)
+    position: relative
+    padding-bottom: 52.1%
+    padding-top: 25px
+    height: 0
+
+    &> iframe
+      position: absolute
+      top: 0
+      left: 0
+      width: 100%
+      height: 100%
 
   .actions
     padding: 15px 10px

--- a/app/styles/_components/comments.sass
+++ b/app/styles/_components/comments.sass
@@ -107,11 +107,14 @@ $max-comment-width: 600px
   .media-content
     overflow: hidden
     max-width: $max-comment-width
+
+  $source-margin: 2px 0 5px
+
   .fact-source
     display: inline-block
     background: $primary-desaturated
     padding: 7px 10px
-    margin: 2px 0 10px
+    margin: $source-margin
     border-radius: 3px
     &:hover
       background: transparentize($primary-desaturated, 0.15)
@@ -126,6 +129,9 @@ $max-comment-width: 600px
     &> .article-title
       font-style: italic
       color: lightgrey
+
+  .video
+    margin: $source-margin
 
   .user-appellation
     display: inline-block

--- a/app/styles/_components/video_player.sass
+++ b/app/styles/_components/video_player.sass
@@ -1,13 +1,3 @@
-.video > div
-  @include animate(fadeIn, 1s)
-  position: relative
-  padding-bottom: 52.1%
-  padding-top: 25px
-  height: 0
-
-  &> iframe
-    position: absolute
-    top: 0
-    left: 0
-    width: 100%
-    height: 100%
+// Display a black box while iframe is loading
+.video
+  background: black

--- a/app/styles/_global/global.sass
+++ b/app/styles/_global/global.sass
@@ -5,10 +5,6 @@ html
   height: 100vh
   overflow-y: auto
 
-.video
-  // Display a black box while iframe is loading
-  background: black
-
 .link-with-icon
   &> *
     display: inline-block

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "smoothscroll-polyfill": "^0.3.6",
     "uuid": "^3.0.1",
     "validator": "^7.0.0",
-    "voca": "^1.3.0",
-    "youtube-regex": "^1.0.5"
+    "voca": "^1.3.0"
   },
   "devDependencies": {
     "auto-reload-brunch": "^2.0.0",


### PR DESCRIPTION
## Improvements regarding rich medias

* Using site_name to check website is not recommended. We extract it from website opengraph or <title> anchor and any website can set any value here. 
Also a website like Facebook would always be listed as a video but a Facebook links can also target posts. We need Regexp here.

* Some players have been disabled. As each one of them loads its little js bundle, it can be heavy if we have too much different players on the same page so we keep only the most popular. We may change this based on usage.

* Sounds like `preloading` option in ReactPlayer was about fixing a bug by playing video silently -not what we seek- and anyway it is already set to false by default. However, Facebook do preload (**pre-fetch is more accurate**) (part of) its content which is a no-go.
So bye bye Facebook.

* Fixed player size

![selection_029](https://user-images.githubusercontent.com/1556356/32598367-c088ea26-c58d-11e7-9adf-d7abaf3a3a3b.png)

## Not directly linked to rich medias

* Youtube-nocookie temporary rollback, see https://github.com/CookPete/react-player/issues/272

* Remove youtube-regex which was using /g flag (wtf?)

----------------

@NGambini You can add commits to this pull request if you see missing or wrong stuff

Close #4 