### PR TITLE
Set maintenance mode by env variable

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -39,7 +39,7 @@ http {
     add_header Strict-Transport-Security "max-age=31536000" always;
 
     # Files path
-    root /var/www;
+    root /var/www/captain_fact;
     index index.html;
     location / {
       try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Maintenance mode is no longer released in a different docker image but instead gets embedded in all releases. To trigger maintenance mode, just set env variable `MAINTENANCE_MODE` to `ON` when deploying container / service.