### PR TITLE
Comments, statements and video debate history UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 * [Extension](https://github.com/CaptainFact/captain-fact-extension)
 
+## Dependencies 
+
+Many thanks to [adorable.io](http://avatars.adorable.io/) for their great consistent avatar service (the funny faces
+you see if you don't set your own profile picture).
+
 ## License
 
 GNU AFFERO GENERAL PUBLIC LICENSE Version 3

--- a/app/assets/assets/help/en/credits.md
+++ b/app/assets/assets/help/en/credits.md
@@ -5,6 +5,8 @@ CaptainFact has grown on upon the soil of many great open source projects such a
 * [React](https://facebook.github.io/react/)
 * [Bulma](http://bulma.io/)
 * [Redux](http://redux.js.org/)
+* [adorable.io](http://avatars.adorable.io/) for their great consistent avatar service (the funny faces 
+  you see if you don't set your own profile picture)
 
 
 And the Wikimedia foundation for all the speakers pictures and other metadata. You

--- a/app/assets/assets/help/fr/credits.md
+++ b/app/assets/assets/help/fr/credits.md
@@ -5,6 +5,8 @@ CaptainFact a grandit sur le sol fertile de nombreux projets open source tels qu
 * [React](https://facebook.github.io/react/)
 * [Bulma](http://bulma.io/)
 * [Redux](http://redux.js.org/)
+* [adorable.io](http://avatars.adorable.io/) for their great consistent avatar service (the funny faces 
+  you see if you don't set your own profile picture)
 
 
 Ainsi qu'à la fondation Wikimedia pour les images d'intervenants et d'autres métadonées associées. Vous

--- a/app/assets/assets/locales/en/videoDebate.json
+++ b/app/assets/assets/locales/en/videoDebate.json
@@ -14,14 +14,19 @@
   "comment": {
     "writeComment": "Write a comment...",
     "addSource": "Add a source to turn this comment into a fact",
-    "postComment": "Post Comment",
+    "post": "Post Comment",
+    "post_reply": "Post reply",
     "deleteThread": "Delete comment",
     "deleteThread_plural": "Delete thread",
     "replies_hide": "Hide replies",
     "replies_show": "Show replies ({{count}})",
     "loadMore_replies": "Load more replies ({{count}})",
     "loadMore_comments": "Load more comments ({{count}})",
-    "replyingTo": "Replying to"
+    "replyingTo": "Replying to",
+    "approve": "Approve",
+    "approve_reply": "Approve this comment",
+    "refute": "Refute",
+    "refute_reply": "Refute this comment"
   },
   "video": {
     "added": "Added",

--- a/app/assets/assets/locales/fr/videoDebate.json
+++ b/app/assets/assets/locales/fr/videoDebate.json
@@ -14,14 +14,19 @@
   "comment": {
     "writeComment": "Écrire un commentaire...",
     "addSource": "Ajouter une source",
-    "postComment": "Poster ce commentaire",
+    "post": "Ajouter en commentaire",
+    "post_reply": "Ajouter en réponse",
     "deleteThread": "Supprimer le commentaire",
     "deleteThread_plural": "Supprimer le fil de discussion",
     "replies_hide": "Cacher les réponses",
     "replies_show": "Montrer les réponses ({{count}})",
     "loadMore_replies": "Charger plus de réponses ({{count}})",
     "loadMore_comments": "Charger plus de commentaires ({{count}})",
-    "replyingTo": "En réponse à"
+    "replyingTo": "En réponse à",
+    "approve": "Approuver",
+    "approve_reply": "Approuver ce commentaire",
+    "refute": "Réfuter",
+    "refute_reply": "Réfuter ce commentaire"
   },
   "video": {
     "added": "Ajoutée",

--- a/app/components/Comments/CommentDisplay.jsx
+++ b/app/components/Comments/CommentDisplay.jsx
@@ -109,12 +109,13 @@ export class CommentDisplay extends React.PureComponent {
   }
 
   render() {
-    const { user, text, source, score, inserted_at } = this.props.comment
+    const { user, text, source, score, inserted_at, approve } = this.props.comment
     const { t, withoutActions, withoutHeader, replyingTo, nesting, replies, myVote, isVoting, hideThread, className, richMedias=true } = this.props
+    const approveClass = approve !== null && (approve ? 'approve' : 'refute')
     return (
       <div>
         <MediaLayout
-          className={classNames('comment', className, {isBlurred: this.state.isBlurred, hasSource: !!source})}
+          className={classNames('comment', className, approveClass, {isBlurred: this.state.isBlurred, hasSource: !!source})}
           ContainerType="article"
           left={
            <figure>

--- a/app/components/Comments/CommentForm.jsx
+++ b/app/components/Comments/CommentForm.jsx
@@ -6,7 +6,7 @@ import isURL from 'validator/lib/isURL'
 import classNames from 'classnames'
 
 import { renderField, validateLength, cleanStrMultiline } from "../FormUtils"
-import { COMMENT_LENGTH, USER_PICTURE_MEDIUM } from "../../constants"
+import { COMMENT_LENGTH, USER_PICTURE_LARGE, USER_PICTURE_MEDIUM } from "../../constants"
 import TextareaAutosize from "../FormUtils/TextareaAutosize"
 import { Icon } from '../Utils/Icon'
 import Tag from '../Utils/Tag'
@@ -70,28 +70,27 @@ export class CommentForm extends React.PureComponent {
     })
   }
 
-  getSubmit(valid, sourceUrl) {
+  getSubmit(valid, sourceUrl, isReply) {
     const commonClasses = ['button', {'is-disabled': !valid}]
-    if (!sourceUrl) return (
-      <button type="submit" className={classNames(commonClasses, 'is-info')}>
-        {this.props.t('comment.postComment')}
+    const i18nParams = isReply ? {context: 'reply'} : null
+    if (!sourceUrl) return ([
+      <button key="comment" type="submit" className={classNames(commonClasses)}>
+        {this.props.t('comment.post', i18nParams)}
       </button>
-    )
-    else return (
-      <div>
-        <button type="submit" className={classNames(commonClasses, 'is-success')}
-          onClick={this.postAndReset(values => this.props.postComment({...values, approve: true}))}>
-          {this.props.t('main:actions.approve')}
-        </button>
-        <button type="submit" className={classNames(commonClasses, 'is-danger')}
-          onClick={this.postAndReset(values => this.props.postComment({...values, approve: false}))}>
-          {this.props.t('main:actions.refute')}
-        </button>
-        <button type="submit" className={classNames(commonClasses)}>
-          {this.props.t('comment.postComment')}
-        </button>
-      </div>
-    )
+    ])
+    else return ([
+      <button key="comment" type="submit" className={classNames(commonClasses)}>
+        {this.props.t('comment.post', i18nParams)}
+      </button>,
+      <button key="approve" type="submit" className={classNames(commonClasses, 'is-success')}
+              onClick={this.postAndReset(values => this.props.postComment({...values, approve: true}))}>
+        {this.props.t('comment.approve', i18nParams)}
+      </button>,
+      <button key="refute" type="submit" className={classNames(commonClasses, 'is-danger')}
+              onClick={this.postAndReset(values => this.props.postComment({...values, approve: false}))}>
+        {this.props.t('comment.refute', i18nParams)}
+      </button>
+    ])
   }
 
   render() {
@@ -103,7 +102,7 @@ export class CommentForm extends React.PureComponent {
         ContainerType="form"
         containerProps={{onSubmit: this.postAndReset(c => this.props.postComment(c))}}
         className="comment-form"
-        left={<UserPicture user={currentUser} size={USER_PICTURE_MEDIUM}/>}
+        left={<UserPicture user={currentUser} size={USER_PICTURE_LARGE}/>}
         content={
           <div>
             {formValues && formValues.reply_to &&
@@ -125,10 +124,14 @@ export class CommentForm extends React.PureComponent {
                    isReply={formValues && !!formValues.reply_to}
                    normalize={ cleanStrMultiline }
                    placeholder={t('comment.writeComment')}/>
-            <Field component={ renderField } name="source.url"
-                   label={t('comment.addSource')}
-                   normalize={s => s.trim()}/>
-            { this.getSubmit(valid, sourceUrl) }
+            <div className="level">
+              <Field component={ renderField } name="source.url"
+                     label={t('comment.addSource')}
+                     normalize={s => s.trim()}/>
+              <div className="submit-btns">
+                { this.getSubmit(valid, sourceUrl, formValues && formValues.reply_to) }
+              </div>
+            </div>
           </div>
         }
       />

--- a/app/components/Comments/Source.jsx
+++ b/app/components/Comments/Source.jsx
@@ -28,7 +28,9 @@ const isPlayer = url => {
 export const Source = ({ source: { url, title, site_name }, withoutPlayer }) => {
   if (!withoutPlayer && isPlayer(url)) {
     return <ReactPlayer  className="video" controls={true} height={180} width={320} url={url}
-                         youtubeConfig={{playerVars: { showinfo: 1 }}}
+                         config={{
+                           youtube: {playerVars: { showinfo: 1 }}
+                         }}
     />
   } else {
     return <a href={url} target="_BLANK" className="fact-source">

--- a/app/components/Users/ResetPasswordConfirmForm.jsx
+++ b/app/components/Users/ResetPasswordConfirmForm.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux'
 import { LoadingFrame } from '../Utils/LoadingFrame'
 import { ErrorView } from '../Utils/ErrorView'
 import UserPicture from './UserPicture'
-import { USER_PICTURE_LARGE } from '../../constants'
+import { USER_PICTURE_XLARGE } from '../../constants'
 import UserAppellation from './UserAppellation'
 import Notification from '../Utils/Notification'
 import {handleEffectResponse} from '../../lib/handle_effect_response'
@@ -64,7 +64,7 @@ export default class ResetPasswordConfirmForm extends React.PureComponent {
       return (
         <div>
           <div className="user-box">
-            <UserPicture user={user} size={USER_PICTURE_LARGE}/>
+            <UserPicture user={user} size={USER_PICTURE_XLARGE}/>
             <UserAppellation user={user} withoutActions={true}/>
           </div>
           {passwordField(this.props.t)}

--- a/app/components/Users/User.jsx
+++ b/app/components/Users/User.jsx
@@ -10,7 +10,7 @@ import ScoreTag from './ScoreTag'
 import MediaLayout from '../Utils/MediaLayout'
 import { LoadingFrame } from '../Utils/LoadingFrame'
 import { TimeSince } from '../Utils/TimeSince'
-import { USER_PICTURE_LARGE } from '../../constants'
+import { USER_PICTURE_XLARGE } from '../../constants'
 import { fetchUser } from '../../state/users/displayed_user/effects'
 import { resetUser } from '../../state/users/displayed_user/reducer'
 
@@ -77,7 +77,7 @@ export default class User extends React.PureComponent {
               {user.id !== 0 &&
                 <MediaLayout
                 left={
-                  <UserPicture user={user} size={USER_PICTURE_LARGE}/>
+                  <UserPicture user={user} size={USER_PICTURE_XLARGE}/>
                 }
                 content={
                   <div>

--- a/app/components/UsersActions/Entity.jsx
+++ b/app/components/UsersActions/Entity.jsx
@@ -37,8 +37,8 @@ export default class Entity extends React.PureComponent {
           { speaker && <strong>{speaker.full_name} </strong> }
           <TimeDisplay time={ reference.time } capitalize={!speaker}
                        handleClick={p => this.props.forcePosition(p)}/>
-          <span> - </span>
-          <div className="statement-text">{ text }</div>
+          <hr/>
+          <div className="statement-text">{text}</div>
         </h4>
       )
     }

--- a/app/constants.js
+++ b/app/constants.js
@@ -23,8 +23,9 @@ export const ENTITY_STATEMENT = 3
 
 /* ------ UI, animations ------ */
 export const USER_PICTURE_SMALL = 24
-export const USER_PICTURE_MEDIUM = 48
-export const USER_PICTURE_LARGE = 96
+export const USER_PICTURE_MEDIUM = 40
+export const USER_PICTURE_LARGE = 48
+export const USER_PICTURE_XLARGE = 96
 
 // Duration during which statement should stay focused
 export const STATEMENT_FOCUS_TIME = 30 // seconds

--- a/app/i18n.js
+++ b/app/i18n.js
@@ -33,8 +33,8 @@ i18n
       prefix: '_translations',
       expirationTime: 48*60*60*1000, // 48h
       versions: {
-        en: "0.7.1",
-        fr: "0.7.1"
+        en: "0.7.2",
+        fr: "0.7.2"
       }
     },
     detection: {

--- a/app/styles/_components/UsersActions/entity.sass
+++ b/app/styles/_components/UsersActions/entity.sass
@@ -1,10 +1,11 @@
 .entity
-  .title .statement-text
-    display: inline-block
+  margin: 0 auto
+  width: fit-content
+  max-width: 90%
+  border: 1px solid $grey-lighter
+  border-radius: 10px
+  padding: 1em 1.5em
+  .statement-text
+    font-weight: lighter
+    text-align: left
 
-  .speaker-preview
-    margin: 0 auto
-    width: fit-content
-    border: 1px solid $grey-lighter
-    border-radius: 10px
-    padding: 1em 1.5em

--- a/app/styles/_components/comments.sass
+++ b/app/styles/_components/comments.sass
@@ -12,13 +12,12 @@ $max-comment-width: 600px
   .reply_to
     margin-bottom: 5px
 
-  .control
-    .textarea
-      $commentboxSize: 60px
-      min-height: $commentboxSize
-      max-height: $commentboxSize * 3
-      height: $commentboxSize
-      resize: none
+  .control .textarea
+    $commentboxSize: 60px
+    min-height: $commentboxSize
+    max-height: $commentboxSize * 3
+    height: $commentboxSize
+    resize: none
 
   .comment-length
     position: absolute
@@ -29,6 +28,22 @@ $max-comment-width: 600px
     margin-left: 3px
     .value.invalid
       color: #ff3d3d
+
+  .level
+    align-items: start
+    margin-bottom: 0.5em
+    .control
+      flex-grow: 0.99
+      flex-direction: column
+    .submit-btns
+      padding-left: 5px
+      .button:not(:first-child):not(.is-disabled)
+        @extend .animated
+        @extend .flipInX
+        border: none
+        animation-duration: 0.3s
+        &:nth-child(3)
+          animation-delay: 0.1s
 
 .facts
   flex-wrap: wrap
@@ -69,6 +84,8 @@ $max-comment-width: 600px
     font-style: italic
     color: grey
 
+  .media-left
+    margin-right: 0.5rem
   .vote, .image
     display: inline-block
     vertical-align: middle
@@ -116,6 +133,7 @@ $max-comment-width: 600px
     padding: 7px 10px
     margin: $source-margin
     border-radius: 3px
+    font-size: 0.9em
     &:hover
       background: transparentize($primary-desaturated, 0.15)
       &> .site-name
@@ -126,6 +144,7 @@ $max-comment-width: 600px
       text-overflow: ellipsis
       display: block
       color: white
+      font-size: 13px
     &> .article-title
       font-style: italic
       color: lightgrey
@@ -139,12 +158,12 @@ $max-comment-width: 600px
       text-decoration: underline
       text-decoration-color: $grey-light
   .comment-actions > a
-    font-size: 12px
-    color: #c7c7c7
+    font-size: 11px
+    color: $grey-light
     margin-right: 15px
     &:hover
       color: darken(#c7c7c7, 25)
-      // font-weight: bold
+      text-decoration: underline
     &> .icon
       font-size: 10px
       vertical-align: middle
@@ -157,17 +176,24 @@ $max-comment-width: 600px
   width: 100%
   padding: 10px
 
+$thread_border_style: 1px solid
+$thread_border_base_color: darken($light, 2)
+
 .comments-list .comments-list
-  padding: 0 0 0 28px
-  &> div:first-child
-    border-left: 1px dotted $grey-lighter
+  padding: 0 0 0 10px
   .comment
     border-top: none
     margin: 0
     padding: 0 0 0 10px
+    border-left: $thread_border_style $thread_border_base_color
+    &.approve
+      border-color: mix($thread_border_base_color, $green, 70%)
+    &.refute
+      border-color: mix($thread_border_base_color, $red, 70%)
 
 .comments-list .comments-list .comments-list
-  padding: 0 0 0 38px
+  padding: 0 0 0 20px
+  border-left: $thread_border_style $thread_border_base_color
   .comment
     padding: 0 0 0 5px
     font-size: 0.9em
@@ -189,10 +215,11 @@ $max-comment-width: 600px
         margin-right: 5px
 
 .comments-list .comments-list .comments-list .comments-list
-  padding: 0 0 0 30px
+  padding: 0 0 0 20px
 
 .comments-list .comments-list .comments-list .comments-list .comments-list
   padding: 0
+  border-left: none
   &> div
     border: none
 

--- a/app/styles/_components/statements.sass
+++ b/app/styles/_components/statements.sass
@@ -34,8 +34,9 @@ $statement-text-color: #e0e7f1
       .time-display
         min-width: 60px
         color: grey
-        border-right: 1px solid #e8e8e8
         margin-right: 15px
+        padding-right: 10px
+        border-right: 1px solid #e8e8e8
       &> *:not(:last-child)
         border-bottom: 1px solid #dbdbdb
         border-top: none
@@ -57,6 +58,10 @@ $statement-text-color: #e0e7f1
           margin-right: 10px
         .speaker-select
           min-width: 200px
+        .time-display
+          border: none
+          padding-right: 0
+          margin-right: 10px
       .textarea
         min-height: 50px
         font-style: italic

--- a/app/styles/_global/global.sass
+++ b/app/styles/_global/global.sass
@@ -26,3 +26,7 @@ html
 
 a.is-disabled
   color: lightgrey
+
+.image.is-40x40
+  height: 40px
+  width: 40px

--- a/app/styles/application.sass
+++ b/app/styles/application.sass
@@ -33,7 +33,7 @@
 @import "animate/fadeIn"
 @import "animate/fadeOut"
 @import "animate/bounceInDown"
-@import "animate/rotateIn"
+@import "animate/flipInX"
 
 @import "react-select/scss/default"
 


### PR DESCRIPTION
# Comments

* Show approve / refute for comments by changing the left border color
* Comments are more compact: less margin left, smaller pictures, and smaller sources
* Comment form:
  - Align submit buttons on the same line as the source url
  - Better labels for buttons if we're replying

## Before
![before](https://user-images.githubusercontent.com/1556356/32874128-57432552-cae4-11e7-8cad-eb3c3737c4dc.png)

## After
![after](https://user-images.githubusercontent.com/1556356/32874131-5bb0f024-cae4-11e7-8279-a8ee44e9d05b.png)


# Statements

## Before
![Before](https://user-images.githubusercontent.com/1556356/32874088-20031548-cae4-11e7-90bc-fbad58018fe6.png)
## After
![After](https://user-images.githubusercontent.com/1556356/32874111-3fcf87da-cae4-11e7-9d24-cda711ad9c7c.png)

# History 

## Speakers before
![selection_066](https://user-images.githubusercontent.com/1556356/32874154-87f36dce-cae4-11e7-978e-6e546f01953f.png)

## Speakers after
![selection_071](https://user-images.githubusercontent.com/1556356/32874183-c791de3e-cae4-11e7-9790-ab74534e23b8.png)

## Statements before
![selection_064](https://user-images.githubusercontent.com/1556356/32874157-8b86690a-cae4-11e7-91ea-824f6a78aa31.png)

## Statements after
![selection_070](https://user-images.githubusercontent.com/1556356/32874181-c4be7d2a-cae4-11e7-8404-c2b52d88e735.png)

