### PR TITLE
Compact statements on mobile + small users pictures + fixes

### DIFF
--- a/app/components/Comments/CommentDisplay.jsx
+++ b/app/components/Comments/CommentDisplay.jsx
@@ -17,7 +17,7 @@ import { addModal } from '../../state/modals/reducer'
 import { commentVote, deleteComment, flagComment } from '../../state/video_debate/comments/effects'
 import {flashErrorUnauthenticated} from '../../state/flashes/reducer'
 import UserPicture from '../Users/UserPicture'
-import { USER_PICTURE_MEDIUM } from '../../constants'
+import { USER_PICTURE_SMALL } from '../../constants'
 import MediaLayout from '../Utils/MediaLayout'
 
 
@@ -132,20 +132,20 @@ export class CommentDisplay extends React.PureComponent {
                      onClick={() => myVote >= 0 ? this.vote(-1) : this.vote(0)}/>
              </div>
              }
-             <UserPicture user={user} size={USER_PICTURE_MEDIUM}/>
            </figure>
           }
           content={
             <div className="content">
               <div>
                 {!withoutHeader && <div className="comment-header">
+                  <UserPicture user={user} size={USER_PICTURE_SMALL}/>
                   <UserAppellation user={user} withoutActions={withoutActions}/>
                   <span> - </span>
                   <TimeSince className="comment-time" time={inserted_at}/>
                 </div>}
                 {source && <Source withoutPlayer={!richMedias} source={source}/>}
                 <div className="comment-text">
-                  {nesting > 4 && replyingTo &&
+                  {nesting > 6 && replyingTo &&
                   <Tag style={{marginRight: 5}}>@{replyingTo.username}</Tag>
                   }
                   { text }

--- a/app/components/Users/UserPicture.jsx
+++ b/app/components/Users/UserPicture.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {staticResource} from '../../API/resources'
 
 
+// TODO In 0.7.8 user picture URL will never be null
 const getImageUrl = (userId, url, url_mini, size) => {
   if (!url || !url_mini)
     return `https://api.adorable.io/avatars/${size}/${userId}.png`

--- a/app/styles/_components/comments.sass
+++ b/app/styles/_components/comments.sass
@@ -68,7 +68,7 @@ $max-comment-width: 600px
       color: grey
 
 .media.comment
-  padding: 0
+  padding: 0.1em 0
   border-top: none
   width: 100%
   &:not(:last-child)
@@ -78,14 +78,15 @@ $max-comment-width: 600px
   &.quoted .comment-text
     font-style: italic
     color: grey
-
+  .user-picture
+    margin-right: 0.25em
   .media-left
     margin-right: 0.5rem
   .vote, .image
     display: inline-block
     vertical-align: middle
   .vote
-    margin-right: 7px
+    margin-top: -5px
     .icon
       display: block
       color: lightgrey
@@ -146,9 +147,11 @@ $max-comment-width: 600px
 
   .video
     margin: $source-margin
+    max-width: 100%
 
   .user-appellation
     display: inline-block
+    font-size: 14px
     &:hover
       text-decoration: underline
       text-decoration-color: $grey-light
@@ -178,9 +181,9 @@ $thread_border_base_color: darken($light, 2)
 .comments-list .comments-list
   padding: 0 0 0 10px
   .comment
-    border-top: none
     margin: 0
-    padding: 0 0 0 10px
+    padding: 0.1em 0 0.1em 10px
+    border-top: none
     border-left: $thread_border_style $thread_border_base_color
     &.approve
       border-color: mix($thread_border_base_color, $green, 70%)
@@ -188,14 +191,15 @@ $thread_border_base_color: darken($light, 2)
       border-color: mix($thread_border_base_color, $red, 70%)
 
 .comments-list .comments-list .comments-list
-  padding: 0 0 0 20px
+  padding: 0.2em 0 0.2em 20px
   border-left: $thread_border_style $thread_border_base_color
   .comment
-    padding: 0 0 0 5px
+    padding: 0 0 0 1em
     font-size: 0.9em
     .media-left
       .vote
         margin-right: 5px
+        margin-top: 0
         .icon
           font-size: 14px
           height: 10px
@@ -211,13 +215,14 @@ $thread_border_base_color: darken($light, 2)
         margin-right: 5px
 
 .comments-list .comments-list .comments-list .comments-list
-  padding: 0 0 0 20px
+  padding: 0.2em 0 0.2em 1.3em
 
 .comments-list .comments-list .comments-list .comments-list .comments-list
-  padding: 0
-  border-left: none
-  &> div
-    border: none
+  padding: 0.1em 1.3em
+  //border-left: none
+
+.comments-list .comments-list .comments-list .comments-list .comments-list .comments-list .comments-list
+  padding: 0.1em 0
 
 .comments-expender
   margin: 5px

--- a/app/styles/_components/statements.sass
+++ b/app/styles/_components/statements.sass
@@ -78,8 +78,8 @@ $statement-text-color: #e0e7f1
 .statement-text-container
   background: $statement-text-background
   color: $statement-text-color
-  box-shadow: 0px 0px 10px 0px rgb(50, 50, 50) inset
-  padding: 1.5rem
+  box-shadow: 0 0 10px 0 rgb(50, 50, 50) inset
+  padding: 1.5em
   &:before
     content: "“"
     font-family: serif
@@ -89,11 +89,19 @@ $statement-text-color: #e0e7f1
     color: $grey-light
     position: absolute
   .statement-text
-    padding: 20px 0 20px 40px
+    padding: 1em 1em 1em 2em
+  +mobile
+    padding: 0em 0.75em
+    &:before
+      font-size: 3em
+    .statement-text
+      padding: 1em 1em 1em 1.5em
+      font-size: 1.25em
 
 .statement-text
   font-style: italic
-  font-size: 20px
+  font-size: 1.45em
   font-weight: bold
   white-space: pre-line
+  text-shadow: 0px 0px 3px black
 

--- a/app/styles/_global/icons.sass
+++ b/app/styles/_global/icons.sass
@@ -22,3 +22,7 @@
   /* Better Font Rendering ===========
   -webkit-font-smoothing: antialiased
   -moz-osx-font-smoothing: grayscale
+
+.icon
+  width: auto
+


### PR DESCRIPTION
# UI changes

## Statement text more compact on mobile

![selection_158](https://user-images.githubusercontent.com/1556356/35073423-cf9abc02-fc3c-11e7-9d99-6cb5c1edb9a3.png)

## Compact users pictures

![selection_157](https://user-images.githubusercontent.com/1556356/35073432-d7f8f9d6-fc3c-11e7-90cf-cc8f83d0f8b3.png)

## Use new space to increase comment stack max size up to 6 levels instead of 4

![selection_159](https://user-images.githubusercontent.com/1556356/35073461-044589d2-fc3d-11e7-8169-ec2c8569f3a7.png)

# Fixes

* Fix a bug with videos embedded inside comments being too large on small devices
