### PR TITLE
Staging

### DIFF
--- a/app/assets/assets/help/en/reputation.md
+++ b/app/assets/assets/help/en/reputation.md
@@ -16,8 +16,7 @@ These rules are subject to change, especially as the number of users grows.
 
 | Action                                                         | Reputation gain          |
 |----------------------------------------------------------------|--------------------------|
-| Your email is verified                                         | +15pts
-| You link your account to one of your social network's profile  | +15pts
+| Verify you email or link a third-party account                 | +15pts
 | One of your comments is voted up                               | +2pts
 | One of your sourced comment is voted up                        | +3pts
 | Someone approves one of your modifications in history          | +5pts

--- a/app/assets/assets/help/fr/privacy.md
+++ b/app/assets/assets/help/fr/privacy.md
@@ -2,7 +2,7 @@ Nous ne vendrons **jamais** vos données personelles et il n'y a pas grand chose
 toutes les façons : on ne collecte que ce dont on a besoin pour faire fonctionner le site.
 
 Vous devez par contre considérer toutes vos intéractions (votes, commentaires...)
-comme **publiques**. Vous êtes libre d'utiliser votre vrai non ou juste un bon view
+comme **publiques**. Vous êtes libre d'utiliser votre vrai nom ou juste un bon vieux
 pseudonyme si c'est ce que vous préférez.
 
 Bien que rien ne soit infaible, nous faisons attention à la sécurité et essayons de suivre les

--- a/app/assets/assets/help/fr/reputation.md
+++ b/app/assets/assets/help/fr/reputation.md
@@ -12,15 +12,15 @@ Gagner en réputation vous permet de débloquer des nouveaux
 [privilèges](/help/privileges). Vous pouvez gagner jusqu'à 25 points de réputation par
 jour (les compteurs sont réinitialisés à minuit).
 
-Ces règles sont sujettes à évolution dans le temps.
+Ces règles sont sujettes à évolution dans le temps, en particulier avec la
+montée du nombre d'utilisateurs.
 
  
 # Pour gagner de la réputation
 
 | Action                                                         | Gain             |
 |----------------------------------------------------------------|------------------|
-| Faire vérifier son email                                       | +15pts
-| Relier au moins un compte tierce (Facebook)                    | +15pts
+| Vérifier son email ou relier un compte tierce (Facebook)       | +15pts
 | Un de vos commentaires recoit un vote positif                  | +2pts
 | Un de vos commentaires **sourcé** recoit un vote positif       | +3pts
 | Quelqu'un approuve une de vos modifications dans l'historique  | +5pts

--- a/app/assets/assets/locales/en/home.json
+++ b/app/assets/assets/locales/en/home.json
@@ -9,7 +9,7 @@
   "creatingAnAccount": "creating an account",
   "invitation": "Ask for an invitation",
   "inviteFriend": "Invite a friend",
-  "footer": "Created with {{iconLove}} in New Caledonia using ",
+  "footer": "Created with {{iconLove}} using ",
   "emailPlaceholder": "Email address",
   "inviteSuccess": "Invitation request confirmed !",
   "error_invalid_email": "Invalid email address"

--- a/app/assets/assets/locales/en/main.json
+++ b/app/assets/assets/locales/en/main.json
@@ -35,6 +35,7 @@
     "remove": "Remove",
     "delete": "Delete",
     "reply": "Reply",
+    "addToThread": "Add to thread",
     "approve": "Approve",
     "refute": "Refute",
     "edit": "Edit",

--- a/app/assets/assets/locales/en/videoDebate.json
+++ b/app/assets/assets/locales/en/videoDebate.json
@@ -23,8 +23,8 @@
     "loadMore_replies": "Load more replies ({{count}})",
     "loadMore_comments": "Load more comments ({{count}})",
     "replyingTo": "Replying to",
-    "approve": "Confirm",
-    "approve_reply": "Confirm this comment",
+    "approve": "Approve",
+    "approve_reply": "Approve this comment",
     "refute": "Refute",
     "refute_reply": "Refute this comment",
     "revealForm": "Add a source or comment"

--- a/app/assets/assets/locales/fr/errors.json
+++ b/app/assets/assets/locales/fr/errors.json
@@ -14,7 +14,7 @@
     "action_already_done": "Cette action a déjà été effectuée",
     "unauthenticated": "Vous devez vous connecter pour effectuer cette action",
     "unauthorized": "Merci de vous (re)connecter pour continuer",
-    "noInternet": "La connection au serveur a échoué, éssayez de rafraichir la page"
+    "noInternet": "La connection au serveur a échoué, essayez de rafraichir la page"
   },
   "client": {
     "joinCrashed": "La connection au serveur a échouée",

--- a/app/assets/assets/locales/fr/home.json
+++ b/app/assets/assets/locales/fr/home.json
@@ -9,7 +9,7 @@
   "creatingAnAccount": "créant un compte",
   "invitation": "Demander une invitation",
   "inviteFriend": "Inviter un ami",
-  "footer": "Créé avec {{iconLove}} en Nouvelle-Calédonie à l'aide d'",
+  "footer": "Créé avec {{iconLove}} à l'aide d'",
   "emailPlaceholder": "Adresse email",
   "inviteSuccess": "Demande d'invitation enregistrée !",
   "error_invalid_email": "Adresse email invalide"

--- a/app/assets/assets/locales/fr/main.json
+++ b/app/assets/assets/locales/fr/main.json
@@ -34,6 +34,7 @@
     "remove": "Retirer",
     "delete": "Supprimer",
     "reply": "Répondre",
+    "addToThread": "Ajouter à la suite",
     "approve": "Confirmer",
     "refute": "Réfuter",
     "edit": "Éditer",

--- a/app/assets/assets/locales/fr/videoDebate.json
+++ b/app/assets/assets/locales/fr/videoDebate.json
@@ -23,10 +23,10 @@
     "loadMore_replies": "Charger plus de réponses ({{count}})",
     "loadMore_comments": "Charger plus de commentaires ({{count}})",
     "replyingTo": "En réponse à",
-    "approve": "Confirmer",
-    "approve_reply": "Confirmer ce commentaire",
-    "refute": "Réfuter",
-    "refute_reply": "Réfuter ce commentaire",
+    "approve": "J'approuve",
+    "approve_reply": "J'approuve ce commentaire",
+    "refute": "Je réfute",
+    "refute_reply": "Je réfute ce commentaire",
     "revealForm": "Ajouter une source ou un commentaire"
   },
   "video": {

--- a/app/components/Comments/CommentDisplay.jsx
+++ b/app/components/Comments/CommentDisplay.jsx
@@ -143,10 +143,10 @@ export class CommentDisplay extends React.PureComponent {
                   <span> - </span>
                   <TimeSince className="comment-time" time={inserted_at}/>
                 </div>}
-                {(text || replyingTo) &&
+                {text || (replyingTo && nesting > 6) &&
                   <div className="comment-text">
-                    {nesting > 6 && replyingTo &&
-                      <Tag style={{marginRight: 5}}>@{replyingTo.username}</Tag>
+                    {(replyingTo && nesting > 6) &&
+                    <Tag style={{marginRight: 5}}>@{replyingTo.username}</Tag>
                     }
                     { text }
                   </div>

--- a/app/components/Comments/CommentForm.jsx
+++ b/app/components/Comments/CommentForm.jsx
@@ -9,7 +9,8 @@ import { withRouter } from 'react-router'
 import { renderField, validateLength, cleanStrMultiline } from "../FormUtils"
 import { COMMENT_LENGTH, USER_PICTURE_LARGE } from "../../constants"
 import TextareaAutosize from "../FormUtils/TextareaAutosize"
-import { Icon } from '../Utils/Icon'
+import CloseButton from '../Utils/CloseButton'
+import Icon from '../Utils/Icon'
 import Tag from '../Utils/Tag'
 import UserAppellation from '../Users/UserAppellation'
 import { postComment } from '../../state/video_debate/comments/effects'
@@ -92,16 +93,16 @@ export class CommentForm extends React.PureComponent {
           <div>
             {formValues && formValues.reply_to &&
             <div>
-              <Tag size="medium" className="reply_to"
-                   onClick={() => this.props.change('reply_to', null)}>
-                <Icon name="times" isClickable={true}/>
+              <Tag size="medium" className="reply_to">
+                <CloseButton onClick={() => this.props.change('reply_to', null)}/>
                 <span>
                   {t('comment.replyingTo')}&nbsp;
                   <UserAppellation user={formValues.reply_to.user}/>
                 </span>
               </Tag>
-              <CommentDisplay className="quoted" richMedias={false} withoutActions withoutHeader hideThread
-                              comment={formValues.reply_to}/>
+              <CommentDisplay className="quoted" richMedias={false}
+                              comment={formValues.reply_to}
+                              withoutActions withoutHeader hideThread/>
               <br/>
             </div>
             }
@@ -137,13 +138,13 @@ export class CommentForm extends React.PureComponent {
       <button key="comment" type="submit" className={classNames(commonClasses)}>
         {this.props.t('comment.post', i18nParams)}
       </button>,
-      <button key="approve" type="submit" className={classNames(commonClasses, 'is-success')}
-              onClick={this.postAndReset(values => this.props.postComment({...values, approve: true}))}>
-        {this.props.t('comment.approve', i18nParams)}
-      </button>,
       <button key="refute" type="submit" className={classNames(commonClasses, 'is-danger')}
               onClick={this.postAndReset(values => this.props.postComment({...values, approve: false}))}>
         {this.props.t('comment.refute', i18nParams)}
+      </button>,
+      <button key="approve" type="submit" className={classNames(commonClasses, 'is-success')}
+              onClick={this.postAndReset(values => this.props.postComment({...values, approve: true}))}>
+        {this.props.t('comment.approve', i18nParams)}
       </button>
     ])
   }

--- a/app/components/Comments/CommentsContainer.jsx
+++ b/app/components/Comments/CommentsContainer.jsx
@@ -31,7 +31,7 @@ export class CommentsContainer extends React.PureComponent {
     return (
       <div className={`comments-list ${className ? className : ''}`}>
         {header && <div className="comments-list-header">{header}</div>}
-        <FlipMove enterAnimation="fade" leaveAnimation={false} typeName={null}>
+        <FlipMove enterAnimation="fade" leaveAnimation={false}>
           {displayedComments.map(comment =>
             <div key={comment.id}>
               <CommentDisplay comment={comment} nesting={nesting} replyingTo={replyingTo}/>

--- a/app/components/Comments/Vote.jsx
+++ b/app/components/Comments/Vote.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import classNames from 'classnames'
+
+import { Icon } from '../Utils'
+
+
+const Vote = ({isVoting, score, myVote, onVote}) => (
+  <figure>
+    <div className="vote">
+      <Icon name="chevron-up" isClickable={true}
+            className={classNames({ selected: myVote > 0 })}
+            onClick={() => myVote <= 0 ? onVote(1) : onVote(0)}/>
+      <div className="score">
+        {isVoting ? <span className="round-spinner"/> : score}
+      </div>
+      <Icon name="chevron-down" isClickable={true}
+            className={classNames({ selected: myVote < 0 })}
+            onClick={() => myVote >= 0 ? onVote(-1) : onVote(0)}/>
+    </div>
+  </figure>
+)
+
+export default Vote

--- a/app/components/Statements/Statement.jsx
+++ b/app/components/Statements/Statement.jsx
@@ -151,21 +151,21 @@ export class Statement extends React.PureComponent {
   renderFactsAndComments() {
     if (this.props.commentsLoading)
       return (<LoadingFrame size="small" title="Loading comments"/>)
-    const { statement, comments, approvingFacts, refutingFacts, currentUser, isAuthenticated } = this.props
+    const { statement, comments, approvingFacts, refutingFacts } = this.props
 
     return (
       <div>
         {(approvingFacts.size > 0 || refutingFacts.size > 0) &&
         <div className="card-footer facts">
-          {approvingFacts.size > 0 &&
-          <CommentsContainer className="card-footer-item approve"
-                             comments={approvingFacts}
-                             header={this.renderCommentsContainerHeader('approve', 'success', this.props.approveScore)}/>
-          }
           {refutingFacts.size > 0 &&
           <CommentsContainer className="card-footer-item refute"
                              comments={refutingFacts}
                              header={this.renderCommentsContainerHeader('refute', 'danger', this.props.refuteScore)}/>
+          }
+          {approvingFacts.size > 0 &&
+          <CommentsContainer className="card-footer-item approve"
+                             comments={approvingFacts}
+                             header={this.renderCommentsContainerHeader('approve', 'success', this.props.approveScore)}/>
           }
         </div>
         }

--- a/app/components/Users/SignupForm.jsx
+++ b/app/components/Users/SignupForm.jsx
@@ -27,15 +27,13 @@ const SignupForm = ({location, t}) => {
       <div className="user-form">
         <Message
           type="warning"
-          header={t('invitationOnlyTitle')}
-          body={
+          header={t('invitationOnlyTitle')}>
             <div>
               {t('invitationOnlyBody')}
               <hr/>
               <InvitationRequestForm/>
             </div>
-          }
-        />
+        </Message>
       </div>
     )
 }

--- a/app/components/Users/ThirdPartyAuthList.jsx
+++ b/app/components/Users/ThirdPartyAuthList.jsx
@@ -10,7 +10,7 @@ const ThirdPartyAuthList = ({t, location: {query: {invitation_token}}}) => (
   <div className="third-party-auth">
     <h4 className="title is-4">{t('actionWithThirdParty')}</h4>
     <div className="services-list">
-      <ThirdPartyServiceButton url={facebookAuthUrl(invitation_token ? {invitation_token} : null)} icon="facebook"/>
+      <ThirdPartyServiceButton url={facebookAuthUrl(invitation_token || "")} icon="facebook"/>
       <ThirdPartyServiceButton url="facebook.com" icon="google" className="is-disabled"/>
       <ThirdPartyServiceButton url="facebook.com" icon="github" className="is-disabled"/>
       <ThirdPartyServiceButton url="facebook.com" icon="twitter" className="is-disabled"/>

--- a/app/components/Users/ThirdPartyCallback.jsx
+++ b/app/components/Users/ThirdPartyCallback.jsx
@@ -20,7 +20,10 @@ export default class ThirdPartyCallback extends React.PureComponent {
     if (!this.props.location.query.error) {
       this.props.login({
         provider: this.props.params.provider,
-        params: this.props.location.query
+        params: {
+          code: this.props.location.query.code,
+          invitation_token: this.props.location.query.state
+        }
       })
     }
   }

--- a/app/components/Utils/CloseButton.jsx
+++ b/app/components/Utils/CloseButton.jsx
@@ -1,0 +1,6 @@
+import React from 'react'
+
+const CloseButton = ({onClick}) =>
+  <a className="delete" onClick={onClick}/>
+
+export default CloseButton

--- a/app/components/Utils/ErrorView.jsx
+++ b/app/components/Utils/ErrorView.jsx
@@ -33,8 +33,7 @@ export class ErrorView extends React.PureComponent {
       <div className="message-view">
         <Message
           type="danger"
-          header={<p><strong>{t('title')}</strong></p>}
-          body={
+          header={<p><strong>{t('title')}</strong></p>}>
             <div>
               <p>{tError(t, error)}{this.getMoreInfo()}</p>
               {(canGoBack || canReload) && <br/>}
@@ -48,7 +47,7 @@ export class ErrorView extends React.PureComponent {
                 {t('main:actions.reload')}
               </LinkWithIcon>}
             </div>
-          }
+        </Message>
         />
       </div>
     )

--- a/app/components/Utils/Icon.jsx
+++ b/app/components/Utils/Icon.jsx
@@ -1,36 +1,20 @@
 import React from "react"
+import classNames from 'classnames'
 
-export class Icon extends React.PureComponent {
-  constructor(props) {
-    super(props)
-  }
 
-  renderIcon(name) {
-    return (<i className={`fa icon-${name}`}/>)
-  }
+export const Icon = ({name, size, withContainer=true, className, isClickable, ...otherProps}) => {
+  const sizeClass = size && `is-${size}`
+  const icon = <i className={`fa icon-${name}`}/>
 
-  render() {
-    const {name, size, withContainer, className, isClickable, ...otherProps} = this.props
-    const sizeClass = size ? ` is-${size} ` : ' '
-    if (withContainer)
-      if (isClickable) return (
-        <a className={`icon${sizeClass}${className}`} {...otherProps}>
-          {this.renderIcon(name)}
-        </a>
-      )
-      else return (
-        <span className={`icon${sizeClass}${className}`} {...otherProps}>
-          {this.renderIcon(name)}
-        </span>
-      )
-    else return this.renderIcon(name)
-  }
+  if (!withContainer)
+    return icon
+
+  const Container = isClickable ? 'a' : 'span'
+  return (
+    <Container className={classNames('icon', className, sizeClass)} {...otherProps}>
+      {icon}
+    </Container>
+  )
 }
 
-Icon.defaultProps = {
-  withContainer: true,
-  isClickable: false,
-  size: "",
-  name: "question",
-  className: ''
-}
+export default Icon

--- a/app/components/Utils/Message.jsx
+++ b/app/components/Utils/Message.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
 
 
-const Message = ({type='info', header='', body=''}) =>
+const Message = ({type='info', header='', children}) =>
   <article className={`message is-${type}`}>
     {header && <div className="message-header">
       {header}
     </div>}
     <div className="message-body">
-      {body}
+      {children}
     </div>
   </article>
 

--- a/app/components/Utils/__tests__/Icon.spec.jsx
+++ b/app/components/Utils/__tests__/Icon.spec.jsx
@@ -1,0 +1,21 @@
+import Icon from '../Icon'
+
+test("render icon", () => {
+  snapshot(<Icon name="plus"/>)
+})
+
+test("set size", () => {
+  snapshot(<Icon name="plus" size="large"/>)
+})
+
+test("render without container", () => {
+  snapshot(<Icon name="plus" withContainer={false}/>)
+})
+
+test("use 'a' if is link", () => {
+  snapshot(<Icon name="plus" isClickable={true}/>)
+})
+
+test("other props get passed to container", () => {
+  snapshot(<Icon name="plus" title="Add some stuff"/>)
+})

--- a/app/components/Utils/__tests__/Message.spec.jsx
+++ b/app/components/Utils/__tests__/Message.spec.jsx
@@ -1,0 +1,17 @@
+import Message from '../Message'
+
+test("render message", () => {
+  snapshot(<Message>Hello</Message>)
+})
+
+test("can set type", () => {
+  snapshot(<Message type="warning">Alert !</Message>)
+})
+
+test("can set header", () => {
+  snapshot(<Message header="Awesome title">Hellooow</Message>)
+})
+
+test("without body", () => {
+  snapshot(<Message/>)
+})

--- a/app/components/Utils/__tests__/Notification.spec.jsx
+++ b/app/components/Utils/__tests__/Notification.spec.jsx
@@ -1,0 +1,17 @@
+import Notification from '../Notification'
+
+test("render message", () => {
+  snapshot(<Notification>Hello</Notification>)
+})
+
+test("can set type", () => {
+  snapshot(<Notification type="warning">Alert !</Notification>)
+})
+
+test("pass props", () => {
+  snapshot(<Notification title="my title">Hellooow</Notification>)
+})
+
+test("without body", () => {
+  snapshot(<Notification/>)
+})

--- a/app/components/Utils/__tests__/Tag.spec.jsx
+++ b/app/components/Utils/__tests__/Tag.spec.jsx
@@ -1,0 +1,9 @@
+import Tag from '../Tag'
+
+test("render tag", () => {
+  snapshot(<Tag>Test</Tag>)
+})
+
+test("set size", () => {
+  snapshot(<Tag type="info">Test</Tag>)
+})

--- a/app/components/Utils/__tests__/__snapshots__/Icon.spec.jsx.snap
+++ b/app/components/Utils/__tests__/__snapshots__/Icon.spec.jsx.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`other props get passed to container 1`] = `
+<span
+  className="icon"
+  title="Add some stuff"
+>
+  <i
+    className="fa icon-plus"
+  />
+</span>
+`;
+
+exports[`render icon 1`] = `
+<span
+  className="icon"
+>
+  <i
+    className="fa icon-plus"
+  />
+</span>
+`;
+
+exports[`render without container 1`] = `
+<i
+  className="fa icon-plus"
+/>
+`;
+
+exports[`set size 1`] = `
+<span
+  className="icon is-large"
+>
+  <i
+    className="fa icon-plus"
+  />
+</span>
+`;
+
+exports[`use 'a' if is link 1`] = `
+<a
+  className="icon"
+>
+  <i
+    className="fa icon-plus"
+  />
+</a>
+`;

--- a/app/components/Utils/__tests__/__snapshots__/Message.spec.jsx.snap
+++ b/app/components/Utils/__tests__/__snapshots__/Message.spec.jsx.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`can set header 1`] = `
+<article
+  className="message is-info"
+>
+  <div
+    className="message-header"
+  >
+    Awesome title
+  </div>
+  <div
+    className="message-body"
+  >
+    Hellooow
+  </div>
+</article>
+`;
+
+exports[`can set type 1`] = `
+<article
+  className="message is-warning"
+>
+  <div
+    className="message-body"
+  >
+    Alert !
+  </div>
+</article>
+`;
+
+exports[`render message 1`] = `
+<article
+  className="message is-info"
+>
+  <div
+    className="message-body"
+  >
+    Hello
+  </div>
+</article>
+`;
+
+exports[`without body 1`] = `
+<article
+  className="message is-info"
+>
+  <div
+    className="message-body"
+  />
+</article>
+`;

--- a/app/components/Utils/__tests__/__snapshots__/Notification.spec.jsx.snap
+++ b/app/components/Utils/__tests__/__snapshots__/Notification.spec.jsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`can set type 1`] = `
+<div
+  className="notification is-warning"
+>
+  Alert !
+</div>
+`;
+
+exports[`pass props 1`] = `
+<div
+  className="notification is-info"
+  title="my title"
+>
+  Hellooow
+</div>
+`;
+
+exports[`render message 1`] = `
+<div
+  className="notification is-info"
+>
+  Hello
+</div>
+`;
+
+exports[`without body 1`] = `
+<div
+  className="notification is-info"
+/>
+`;

--- a/app/components/Utils/__tests__/__snapshots__/Tag.spec.jsx.snap
+++ b/app/components/Utils/__tests__/__snapshots__/Tag.spec.jsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render tag 1`] = `
+<div
+  className="tag is-small"
+>
+  Test
+</div>
+`;
+
+exports[`set size 1`] = `
+<div
+  className="tag is-small is-info"
+>
+  Test
+</div>
+`;

--- a/app/components/VideoDebate/Presence.jsx
+++ b/app/components/VideoDebate/Presence.jsx
@@ -8,11 +8,11 @@ import Tag from '../Utils/Tag'
 
 const Presence = ({t, nbUsers, nbViewers}) =>
   <div className="presence">
-    <Tag size="medium" type="danger">
+    <Tag size="medium" type="primary">
       <Icon size="small" name="group"/>
       <span>{t('presence.user', {count: nbUsers})}</span>
     </Tag>
-    <Tag size="medium" type="success">
+    <Tag size="medium" className="viewers">
       <Icon size="small" name="eye"/>
       <span>{t('presence.viewer', {count: nbViewers})}</span>
     </Tag>

--- a/app/lib/third_party_auth.js
+++ b/app/lib/third_party_auth.js
@@ -5,7 +5,8 @@ import { optionsToQueryString } from './url_utils'
 export const facebookAuthUrl = callbackOptions =>
   `https://www.facebook.com/v2.8/dialog/oauth${optionsToQueryString({
     client_id: FB_APP_ID,
-    redirect_uri: `${FRONTEND_URL}/login/callback/facebook${optionsToQueryString(callbackOptions)}`,
+    redirect_uri: `${FRONTEND_URL}/login/callback/facebook`,
     response_type: 'code',
-    scope: "email,public_profile"
+    scope: "email,public_profile",
+    state: callbackOptions
   })}`

--- a/app/styles/_components/App/sidebar.sass
+++ b/app/styles/_components/App/sidebar.sass
@@ -1,7 +1,6 @@
 $border-color: lightgrey
 
 #sidebar
-  @include animate(fadeIn, 0.5s)
   background: $white-bis
   overflow-y: auto
   overflow-x: hidden

--- a/app/styles/_components/VideoDebate/presence.sass
+++ b/app/styles/_components/VideoDebate/presence.sass
@@ -4,5 +4,7 @@
     border-radius: 0.2em
     font-size: 0.8em
     float: right
+    &.viewers
+      border: 1px solid $grey-lighter
   .icon
     margin-right: 0.25em

--- a/app/styles/_components/comments.sass
+++ b/app/styles/_components/comments.sass
@@ -15,6 +15,8 @@ $max-comment-width: 600px
 
   .reply_to
     margin-bottom: 5px
+    .delete
+      margin-right: 0.5em
 
   .control .textarea
     $commentboxSize: 60px
@@ -68,16 +70,18 @@ $max-comment-width: 600px
       color: grey
 
 .media.comment
-  padding: 0.1em 0
   border-top: none
   width: 100%
   &:not(:last-child)
     margin: 0
   &.isBlurred
     filter: blur(2px)
-  &.quoted .comment-text
+  &.quoted
     font-style: italic
-    color: grey
+    color: $grey
+    border-left: 0.25em solid $grey-lighter
+    padding-left: 0.5em
+    margin-left: 0.5em
   .user-picture
     margin-right: 0.25em
   .media-left
@@ -114,25 +118,6 @@ $max-comment-width: 600px
   .comment-time
     font-size: 11px
     color: #949494
-  .comment-text
-    white-space: pre-wrap
-    word-wrap: break-word
-    background-color: $white
-    padding: 0.5em 1em
-    border: 1px solid $grey-lighter
-    border-radius: 0 0.5em 0.5em 0.5em
-    display: inline-block
-    +tablet
-      &:before
-        width: 0
-        height: 0
-        border-left: 8px solid transparent
-        border-right: 8px solid transparent
-        border-bottom: 8px solid white
-        position: absolute
-        left: 0.35em
-        margin-top: -1em
-        content: ''
   .media-content
     overflow: hidden
     max-width: $max-comment-width
@@ -173,20 +158,40 @@ $max-comment-width: 600px
     &:hover
       text-decoration: underline
       text-decoration-color: $grey-light
-  .comment-actions > a
-    font-size: 11px
-    color: $grey-light
-    margin-right: 15px
-    &:hover
-      color: darken(#c7c7c7, 25)
-      text-decoration: underline
-    &> .icon
-      font-size: 10px
-      vertical-align: middle
-      width: 10px
   .action-report.selected
     color: $red
     pointer-events: none
+
+.media.comment:not(.quoted) .comment-text
+  white-space: pre-wrap
+  word-wrap: break-word
+  background-color: $white
+  padding: 0.4em 0.7em
+  border: 1px solid $grey-lighter
+  border-radius: 0 0.5em 0.5em 0.5em
+  display: inline-block
+  +tablet
+    &:before
+      width: 0
+      height: 0
+      border-left: 8px solid transparent
+      border-right: 8px solid transparent
+      border-bottom: 8px solid white
+      position: absolute
+      left: 0.35em
+      margin-top: -0.9em
+      content: ''
+
+.comment-actions a
+  font-size: 0.8em
+  color: $grey-light
+  margin-right: 1em
+  &:hover
+    color: darken(#c7c7c7, 25)
+    text-decoration: underline
+  &> .icon
+    font-size: 0.8em
+    vertical-align: middle
 
 .comments-list
   width: 100%

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "captain-fact-frontend",
-  "version": "0.8.0",
+  "version": "0.8.2",
   "private": true,
   "scripts": {
     "start": "brunch watch --server",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,20 @@
     "serve": "brunch watch --server -n",
     "watch": "jest --watch",
     "test": "jest",
-    "coverage": "jest --coverage '--collectCoverageFrom=app/+(API|lib|state)/**/!(record).{js,jsx}'"
+    "wtest": "jest --watch",
+    "coverage": "jest --coverage '--collectCoverageFrom=app/+(API|components|lib|state)/**/!(record).{js,jsx}'"
+  },
+  "jest": {
+    "setupFiles": [
+      "./tests_setup.js"
+    ],
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ],
+    "moduleNameMapper": {
+      "^.+\\.(css|scss)$": "identity-obj-proxy",
+      "\\.(jpg|jpeg|png)$": "<rootDir>/src/__mocks__/fileMock.js"
+    }
   },
   "dependencies": {
     "animate.scss": "0.0.6",
@@ -61,6 +74,9 @@
     "babel-register": "^6.22.0",
     "brunch": "2.10.9",
     "clean-css-brunch": "^2.10.0",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1",
+    "enzyme-to-json": "^3.3.1",
     "gzip-brunch": "^1.3.0",
     "html-pages-brunch": "^2.6.0",
     "jest": "^22.0.6",

--- a/tests_setup.js
+++ b/tests_setup.js
@@ -1,0 +1,17 @@
+import Enzyme, { shallow, render, mount } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+import React from 'react'
+
+
+global.React = React
+
+// React 16 Enzyme adapter
+Enzyme.configure({ adapter: new Adapter() })
+
+// Make Enzyme functions available in all test files without importing
+global.shallow = shallow
+global.render = render
+global.mount = mount
+
+// Add a helper to register snapshot
+global.snapshot = component => expect(shallow(component)).toMatchSnapshot()


### PR DESCRIPTION
# Improvements

* Enforce strict redirect for Facebook OAuth
* Fix typos in help pages
* UI improvements
  * Remove "in New Caledonia" on homepage as team is now dispatched
  * Show "Add to thread" instead of "Reply" on self comments
  * (French) Show "J'approuve" instead of "Confirmer" (it was error-prone for users)
  * Improve comment display
  * Improve comment form quoted reply display
  * Invert approve / refute columns and buttons positions
  * Use more neutral colors for presence indicators (primary + neutral)

# Tests

* Added some snapshot tests