### PR TITLE
Use more compact comments list headers

### DIFF
--- a/app/components/Comments/CommentsContainer.jsx
+++ b/app/components/Comments/CommentsContainer.jsx
@@ -9,38 +9,55 @@ import { CommentDisplay } from './CommentDisplay'
 export class CommentsContainer extends React.PureComponent {
   constructor(props) {
     super(props)
-    this.state = {nbComments: CommentsContainer.getNbDisplayedRange(props.nesting || 1)}
+    this.state = {
+      nbComments: CommentsContainer.getNbDisplayedRange(props.nesting || 1)
+    }
   }
 
   render() {
     const {t, comments, className, header, replyingTo, nesting = 1} = this.props
-
     let numComment = 0
     const displayedComments = comments.takeWhile(c =>
       ++numComment <= this.state.nbComments[0] ||
       (numComment <= this.state.nbComments[1] && c.score > -1)
     )
+
     return (
       <div className={`comments-list ${className || ''}`}>
-        {header && <div className="comments-list-header">{header}</div>}
+        {header &&
+          <div className="comments-list-header">
+            <div/>
+            <span>{header}</span>
+            <div/>
+          </div>
+        }
         <FlipMove enterAnimation="fade" leaveAnimation={false}>
-          {displayedComments.map(comment =>
+          {displayedComments.map(comment => (
             <div key={comment.id}>
-              <CommentDisplay comment={comment} nesting={nesting} replyingTo={replyingTo}/>
+              <CommentDisplay
+                comment={comment}
+                nesting={nesting}
+                replyingTo={replyingTo}
+              />
             </div>
-          )}
+          ))}
         </FlipMove>
         {displayedComments.size < comments.size &&
           <div className="comments-expender">
-            <a className="button"
+            <button
+              className="button"
               onClick={() => this.setState({
-                nbComments: [this.state.nbComments[0] + 5, this.state.nbComments[1] + 7]
-              })}>
+                nbComments: [
+                  this.state.nbComments[0] + 5,
+                  this.state.nbComments[1] + 7
+                ]
+              })}
+            >
               {t('comment.loadMore', {
                 context: nesting === 1 ? 'comments' : 'replies',
                 count: comments.size - displayedComments.size}
               )}
-            </a>
+            </button>
           </div>
         }
       </div>

--- a/app/components/Statements/Statement.jsx
+++ b/app/components/Statements/Statement.jsx
@@ -149,11 +149,11 @@ export class Statement extends React.PureComponent {
     )
   }
 
-  renderCommentsContainerHeader(label, tagType, score) {
+  renderCommentsContainerHeader(label, tagType, score = null) {
     return (
-      <div>
+      <div className="comments-container-header">
         <span>{this.props.t(label)} </span>
-        <Tag type={tagType}>{ score }</Tag>
+        {score !== null && <Tag type={tagType}>{ score }</Tag>}
       </div>
     )
   }
@@ -182,7 +182,12 @@ export class Statement extends React.PureComponent {
         </div>
         }
         <div className="card-footer comments">
-          {comments.size > 0 && <CommentsContainer comments={comments}/>}
+          {comments.size > 0 &&
+            <CommentsContainer
+              comments={comments}
+              header={this.renderCommentsContainerHeader('comments')}
+            />
+          }
           <CommentForm
             form={`formAddComment-${statement.id}`}
             initialValues={{ statement_id: statement.id }}

--- a/app/i18n/en/videoDebate.js
+++ b/app/i18n/en/videoDebate.js
@@ -3,6 +3,7 @@ export default {
   history: 'History',
   approve: 'Confirm',
   refute: 'Refute',
+  comments: 'Comments',
   flagForm: {
     title: 'Why do you want to flag this comment ?',
     xAvailable: '{{count}} available',

--- a/app/i18n/fr/videoDebate.js
+++ b/app/i18n/fr/videoDebate.js
@@ -3,6 +3,7 @@ export default {
   history: 'Historique',
   approve: 'Confirme',
   refute: 'Réfute',
+  comments: 'Commentaires',
   flagForm: {
     title: 'Pourquoi signaler ce commentaire ?',
     xAvailable: '{{count}} disponnible',

--- a/app/styles/_components/VideoDebate/comments/comments_list.sass
+++ b/app/styles/_components/VideoDebate/comments/comments_list.sass
@@ -1,5 +1,24 @@
 @import "./variables"
 
+/* Header above comments list (approve, refute, comments) */
+
+.comments-list-header
+  font-weight: bold
+  -webkit-box-align: center
+  align-items: center
+  margin-bottom: 0.5em
+  display: flex
+  .tag
+    border-radius: 1em
+    padding: 0 1em
+  &> div
+    height: 1px
+    background: $grey-lighter
+    flex: 1
+    vertical-align: baseline
+    
+.comments-container-header
+  padding: 0 0.5em
 
 /* Approve / refute columns */
 
@@ -8,10 +27,8 @@
   .comments-list
     &.approve .comments-list-header
       color: darken($green, 5)
-      border-bottom: 1px solid $green
     &.refute .comments-list-header
       color: darken($red, 5)
-      border-bottom: 1px solid $red
     &.approve, &.refute
       width: 50%
       flex-direction: column
@@ -22,14 +39,10 @@
         flex-basis: 300px
       &> div
         width: 100%
-    .comments-list-header
-      font-weight: bold
-      text-align: center
-      padding-bottom: 0.4em
-      margin-bottom: 1em
-      .tag
-        border-radius: 1em
-        padding: 0 1em
+    &.approve .comments-list-header > div
+      background: $green
+    &.refute .comments-list-header > div
+      background: $red
 
 /* Button to load more comments */
 


### PR DESCRIPTION
This PR comes as a necessary step to implement [auto-sourcing](https://trello.com/c/F7l7UKfi/720-auto-sourcing) with a coherent interface.

![Preview](https://user-images.githubusercontent.com/1556356/40891577-52f8ae36-6788-11e8-9ae3-cad67f4f304a.png)

----------------
Trello: https://trello.com/c/lZGiXmdQ/673-test-ui-more-compact-approve-refute-headers