### PR TITLE
Add video form: Accept url as URL param (/videos/add?url=xxx)

### DIFF
--- a/app/components/Videos/AddVideoForm.jsx
+++ b/app/components/Videos/AddVideoForm.jsx
@@ -20,15 +20,16 @@ const validate = ({ url }) => {
 
 @withRouter
 @connect((state, props) => ({
-  initialValues: {url: props.params.videoUrl},
+  initialValues: {url: props.params.videoUrl || props.location.query.url},
   isSubmitting: state.Videos.isSubmitting,
   isAuthenticated: isAuthenticated(state)
 }), {postVideo, searchVideo})
 @reduxForm({form: 'AddVideo', validate})
 export class AddVideoForm extends React.PureComponent {
   componentDidMount() {
-    if (this.props.params.videoUrl) {
-      this.props.searchVideo(decodeURI(this.props.params.videoUrl)).then(action => {
+    const videoUrl = this.props.params.videoUrl || this.props.location.query.url
+    if (videoUrl) {
+      this.props.searchVideo(decodeURI(videoUrl)).then(action => {
         if (!action.error && action.payload !== null)
           this.props.router.push(`/videos/${action.payload.id}`)
       })


### PR DESCRIPTION
# What

### Old URL scheme
`/videos/add/https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DSP5MYeBdxiE`

### New URL scheme
`/videos/add?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DSP5MYeBdxiE`

# Why

* More standard
* Was encountering bugs with this on chrome on localhost
* Prettier
* It will be easier to accept different params in the future. For example, we could accept a provider and an id, like: `/videos/add?provider=youtube&id=3DSP5MYeBdxiE`

# How

Component now support both schemes but the old one should be removed all extensions have been migrated to `>= 0.8.4`