### PR TITLE
Allow null comment user (anonymous)

### DIFF
--- a/app/components/Comments/CommentDisplay.jsx
+++ b/app/components/Comments/CommentDisplay.jsx
@@ -41,7 +41,7 @@ export class CommentDisplay extends React.PureComponent {
     const { t, withoutActions, withoutHeader, replyingTo, nesting, replies, myVote, isVoting, hideThread, className, richMedias = true } = this.props
     const approveClass = approve !== null && (approve ? 'approve' : 'refute')
     const showReplies = this.state.showReplies
-    const isOwnComment = this.props.comment.user.id === this.props.currentUser.id
+    const isOwnComment = user && user.id === this.props.currentUser.id
 
     return (
       <div>
@@ -64,12 +64,13 @@ export class CommentDisplay extends React.PureComponent {
           content={
             <div>
               <div>
-                {!withoutHeader && <div className="comment-header">
-                  <UserPicture user={user} size={USER_PICTURE_SMALL}/>
-                  <UserAppellation user={user} withoutActions={withoutActions}/>
-                  <span> - </span>
-                  <TimeSince className="comment-time" time={inserted_at}/>
-                </div>}
+                {!withoutHeader && (
+                  <div className="comment-header">
+                    {this.renderUserHeader(user, withoutActions)}
+                    <span> - </span>
+                    <TimeSince className="comment-time" time={inserted_at}/>
+                  </div>
+                )}
                 {(text || (replyingTo && nesting > 6)) &&
                 <div className="comment-text">
                   {(replyingTo && nesting > 6) &&
@@ -141,6 +142,22 @@ export class CommentDisplay extends React.PureComponent {
         </a>
       </ReputationGuard>
     </React.Fragment>
+  }
+
+  renderUserHeader(user, withoutActions) {
+    if (!user) {
+      return (
+        <span className="anonymous">
+          Utilisateur anonyme
+        </span>
+      )
+    }
+    return (
+      <span>
+        <UserPicture user={user} size={USER_PICTURE_SMALL}/>
+        <UserAppellation user={user} withoutActions={withoutActions}/>
+      </span>
+    )
   }
 
   getScore() {

--- a/app/components/Comments/CommentDisplay.jsx
+++ b/app/components/Comments/CommentDisplay.jsx
@@ -145,17 +145,14 @@ export class CommentDisplay extends React.PureComponent {
   }
 
   renderUserHeader(user, withoutActions) {
-    if (!user) {
-      return (
-        <span className="anonymous">
-          {this.props.t('anonymous')}
-        </span>
-      )
-    }
-    return (
+    return user ? (
       <span>
         <UserPicture user={user} size={USER_PICTURE_SMALL}/>
         <UserAppellation user={user} withoutActions={withoutActions}/>
+      </span>
+    ) : (
+      <span className="anonymous">
+        {this.props.t('anonymous')}
       </span>
     )
   }

--- a/app/components/Comments/CommentDisplay.jsx
+++ b/app/components/Comments/CommentDisplay.jsx
@@ -148,7 +148,7 @@ export class CommentDisplay extends React.PureComponent {
     if (!user) {
       return (
         <span className="anonymous">
-          Utilisateur anonyme
+          {this.props.t('anonymous')}
         </span>
       )
     }

--- a/app/components/Users/DeleteUserModal.jsx
+++ b/app/components/Users/DeleteUserModal.jsx
@@ -22,9 +22,9 @@ class DeleteForm extends React.PureComponent {
         <h4 className="title is-4">Deleting your account will...</h4>
         <ul>
           <li>Delete all your votes</li>
-          <li>Delete all your comments</li>
           <li>Delete all your flags</li>
           <li>Delete all your personal data (email, username...etc)</li>
+          <li>Anonymize all your comments</li>
           <li>Anonymize your actions history</li>
         </ul>
         <hr/>

--- a/app/i18n/en/main.js
+++ b/app/i18n/en/main.js
@@ -64,4 +64,5 @@ export default {
   all: 'All',
   partners: 'Partners',
   users: 'Users',
+  anonymous: 'Anonymous user'
 }

--- a/app/i18n/fr/main.js
+++ b/app/i18n/fr/main.js
@@ -62,5 +62,6 @@ export default {
   },
   all: 'Toutes',
   partners: 'Partenaires',
-  users: 'Utilisateurs'
+  users: 'Utilisateurs',
+  anonymous: 'Utilisateur anonyme'
 }

--- a/app/state/video_debate/comments/record.js
+++ b/app/state/video_debate/comments/record.js
@@ -1,6 +1,5 @@
 import { Record } from 'immutable'
 
-import User from '../../users/record'
 import Source from './source_record'
 
 
@@ -8,7 +7,7 @@ const Comment = new Record({
   id: 0,
   reply_to_id: null,
   is_reported: false,
-  user: new User(),
+  user: null,
   source: new Source(),
   statement_id: 0,
   text: '',

--- a/app/state/video_debate/comments/selectors.js
+++ b/app/state/video_debate/comments/selectors.js
@@ -19,7 +19,7 @@ export const classifyComments = createCachedSelector(
     const regularComments = []
 
     for (const comment of comments) {
-      if (comment.user.speaker_id && comment.user.speaker_id === speakerId)
+      if (isSelfComment(comment, speakerId))
         selfComments.push(comment)
       else if (!comment.source || comment.approve === null)
         regularComments.push(comment)
@@ -37,3 +37,7 @@ export const classifyComments = createCachedSelector(
   }
 )((state, props) => props.statement.id)
 
+// ---- Private ----
+function isSelfComment({user}, speakerId) {
+  return user && user.speaker_id && user.speaker_id === speakerId 
+}

--- a/app/styles/_components/VideoDebate/comments/comment.sass
+++ b/app/styles/_components/VideoDebate/comments/comment.sass
@@ -42,6 +42,10 @@
 
   /* Comment metadata */
 
+  .comment-header
+    .anonymous
+      color: $grey
+      font-style: italic
   .user-picture
     margin-right: 0.25em
     display: inline-block


### PR DESCRIPTION
Deleting an account is not deleting its comments anymore. Instead all user's comments are nullified.

We display `Anonymous user` instead of user's name above comment.

![Preview](https://user-images.githubusercontent.com/1556356/43454055-17425412-94bc-11e8-8455-493678869cc9.png)
