### PR TITLE
Use external link icon on speaker's page wiki links

### DIFF
--- a/app/components/Speakers/SpeakerPage.jsx
+++ b/app/components/Speakers/SpeakerPage.jsx
@@ -77,12 +77,11 @@ export class SpeakerPage extends React.PureComponent {
   renderWikidata() {
     if (this.props.wikiLoading)
       return '...'
-    return [
-      this.renderLink(this.props.links.wikipedia, 'Wikipedia'),
-      this.renderLink(this.props.links.wikimedia, 'Wikimedia'),
-      this.renderLink(this.props.links.wikiquote, 'Wikiquote'),
-      this.renderLink(this.props.links.wikinews, 'Wikinews'),
-    ]
+    return (
+      <React.Fragment>
+        {this.renderLink(this.props.links.wikipedia, 'Wikipedia')}
+      </React.Fragment>
+    )
   }
 
   renderVideos() {
@@ -95,8 +94,8 @@ export class SpeakerPage extends React.PureComponent {
     if (!url)
       return null
     return (
-      <ExternalLinkNewTab href={url} key={url} className="link-with-icon">
-        <Icon name="link" /> <span>{siteName}</span>
+      <ExternalLinkNewTab href={url} className="link-with-icon">
+        <Icon name="external-link" /> <span>{siteName}</span>
       </ExternalLinkNewTab>
     )
   }

--- a/app/components/Speakers/SpeakerPage.jsx
+++ b/app/components/Speakers/SpeakerPage.jsx
@@ -77,11 +77,7 @@ export class SpeakerPage extends React.PureComponent {
   renderWikidata() {
     if (this.props.wikiLoading)
       return '...'
-    return (
-      <React.Fragment>
-        {this.renderLink(this.props.links.wikipedia, 'Wikipedia')}
-      </React.Fragment>
-    )
+    return this.renderLink(this.props.links.wikipedia, 'Wikipedia')
   }
 
   renderVideos() {


### PR DESCRIPTION
https://trello.com/c/vwO85slG/818-use-external-link-icon-on-speakers-page-wiki-links

![Before](https://user-images.githubusercontent.com/1556356/44039731-f770820e-9f19-11e8-9132-32910ee55b4d.png)
![After](https://user-images.githubusercontent.com/1556356/44039733-f892ad2e-9f19-11e8-94b2-87e117e1f4d5.png)

Also disabled other links to Wikimedia, Wikiquotes and Wikinews as we specified previously that this was not very useful. 