### PR TITLE
Fix help page colors and add missing translation

### DIFF
--- a/app/components/Help/Help.jsx
+++ b/app/components/Help/Help.jsx
@@ -27,7 +27,7 @@ export default class Help extends React.PureComponent {
     }
     return (
       <div className="help-page">
-        <section className="hero is-info is-bold">
+        <section className="hero is-primary is-bold">
           <div className="hero-body">
             <div className="section">
               { header }
@@ -45,7 +45,7 @@ export default class Help extends React.PureComponent {
   renderIndexContent() {
     return (
       <div>
-        <Message type="info" header="A propos des pages d'aide">
+        <Message type="primary" header={this.props.t('aboutTitle')}>
           {this.props.t('about')}&nbsp;
           <Trans i18nKey="toStart">
             toStart

--- a/app/i18n/en/help.js
+++ b/app/i18n/en/help.js
@@ -24,6 +24,7 @@ export default {
   },
   title: 'Help',
   goBack: 'Go back to help index',
+  aboutTitle: 'About help pages',
   about: 'The help pages are there to make it easier for you to get started with the platform. They are deliberately short and are strongly encouraged to be read before any participation to the fact-checking process.',
   toStart: 'To get started, take a look at the <1>contribution guidelines</1> as well as explanations of <2>privileges</2> and the <3>reputation system</3>.'
 }

--- a/app/i18n/fr/help.js
+++ b/app/i18n/fr/help.js
@@ -24,7 +24,7 @@ export default {
   },
   title: 'Aide',
   goBack: 'Retourner au menu d\'aide principal',
-  aboutTitle: "A propos des pages d'aide",
+  aboutTitle: "À propos des pages d'aide",
   about: "Les pages d'aide sont là pour faciliter la prise en main de la plateforme. Elles sont volontairement courtes et leur lecture est fortement encouragée avant de participer au travail de vérification.",
   toStart: "Pour commencer, jetez un coup d'oeuil au <1>guide de contribution</1> ainsi qu'aux explications des <2>privilèges</2> et du <3>système de réputation</3>."
 }

--- a/app/i18n/fr/help.js
+++ b/app/i18n/fr/help.js
@@ -24,6 +24,7 @@ export default {
   },
   title: 'Aide',
   goBack: 'Retourner au menu d\'aide principal',
+  aboutTitle: "A propos des pages d'aide",
   about: "Les pages d'aide sont là pour faciliter la prise en main de la plateforme. Elles sont volontairement courtes et leur lecture est fortement encouragée avant de participer au travail de vérification.",
   toStart: "Pour commencer, jetez un coup d'oeuil au <1>guide de contribution</1> ainsi qu'aux explications des <2>privilèges</2> et du <3>système de réputation</3>."
 }


### PR DESCRIPTION
These are **not** the final colors, just a fix to avoid breaking user's eyes while @raphaelecorse finish the graphical contract.

### Before

![Before](https://user-images.githubusercontent.com/1556356/44088180-8135cb22-9fc2-11e8-9ae5-c44589d40789.png)

### After

![After](https://user-images.githubusercontent.com/1556356/44088182-82871bd4-9fc2-11e8-9227-e5f3a33463ed.png)
