### PR TITLE
Add UT for video-debate/video/reducer

### DIFF
--- a/app/state/video_debate/video/__tests__/__fixtures__/fetch_all_success.json
+++ b/app/state/video_debate/video/__tests__/__fixtures__/fetch_all_success.json
@@ -1,0 +1,14 @@
+{
+  "speakers": [
+    {
+      "id": 1,
+      "title": "Title 1",
+      "full_name": "Joseph Philips"
+    },
+    {
+      "id": 2,
+      "title": "Title 2",
+      "full_name": "Jonh Mac"
+    }
+  ]
+}

--- a/app/state/video_debate/video/__tests__/__snapshots__/reducer.spec.js.snap
+++ b/app/state/video_debate/video/__tests__/__snapshots__/reducer.spec.js.snap
@@ -1,0 +1,458 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`add speaker 1`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": null,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;
+
+exports[`add speaker 2`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [
+      Immutable.Record {
+        "id": 3,
+        "slug": null,
+        "full_name": "Max Fray",
+        "title": "Title 3",
+        "picture": "",
+        "country": null,
+        "wikidata_item_id": null,
+      },
+    ],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": null,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;
+
+exports[`fetch all 1`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": null,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;
+
+exports[`fetch all 2`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [
+      Immutable.Record {
+        "id": 1,
+        "slug": null,
+        "full_name": "Joseph Philips",
+        "title": "Title 1",
+        "picture": "",
+        "country": null,
+        "wikidata_item_id": null,
+      },
+      Immutable.Record {
+        "id": 2,
+        "slug": null,
+        "full_name": "Jonh Mac",
+        "title": "Title 2",
+        "picture": "",
+        "country": null,
+        "wikidata_item_id": null,
+      },
+    ],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": null,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;
+
+exports[`force Position 1`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": null,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;
+
+exports[`force Position 2`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": Object {
+      "forcedPosition": Object {
+        "requestId": 1,
+        "time": 0,
+      },
+      "position": 4,
+    },
+    "forcedPosition": Immutable.Record {
+      "requestId": "c28f71b0-c9be-11e8-906f-d1436ce1bc3a",
+      "time": Object {
+        "forcedPosition": Object {
+          "requestId": 1,
+          "time": 0,
+        },
+        "position": 4,
+      },
+    },
+  },
+}
+`;
+
+exports[`has correct defaults 1`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": null,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;
+
+exports[`remove speaker 1`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": null,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;
+
+exports[`remove speaker 2`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": null,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;
+
+exports[`set Loading 1`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": null,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;
+
+exports[`set Loading 2`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": true,
+  "playback": Immutable.Record {
+    "position": null,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;
+
+exports[`set Loading 3`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": null,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;
+
+exports[`set Position 1`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": null,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;
+
+exports[`set Position 2`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": NaN,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;
+
+exports[`update speaker 1`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": null,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;
+
+exports[`update speaker 2`] = `
+Immutable.Record {
+  "data": Immutable.Record {
+    "id": 0,
+    "hash_id": null,
+    "posted_at": 0,
+    "provider": "",
+    "provider_id": 0,
+    "url": "",
+    "title": "",
+    "speakers": Immutable.List [],
+    "language": null,
+    "is_partner": null,
+  },
+  "errors": null,
+  "isLoading": false,
+  "playback": Immutable.Record {
+    "position": null,
+    "forcedPosition": Immutable.Record {
+      "requestId": null,
+      "time": 0,
+    },
+  },
+}
+`;

--- a/app/state/video_debate/video/__tests__/__snapshots__/reducer.spec.js.snap
+++ b/app/state/video_debate/video/__tests__/__snapshots__/reducer.spec.js.snap
@@ -184,7 +184,7 @@ Immutable.Record {
       "position": 4,
     },
     "forcedPosition": Immutable.Record {
-      "requestId": "c28f71b0-c9be-11e8-906f-d1436ce1bc3a",
+      "requestId": "A-UNIQUE-UUID",
       "time": Object {
         "forcedPosition": Object {
           "requestId": 1,

--- a/app/state/video_debate/video/__tests__/reducer.spec.js
+++ b/app/state/video_debate/video/__tests__/reducer.spec.js
@@ -1,0 +1,65 @@
+import reducer, {
+    fetchAll,
+    setLoading,
+    addSpeaker,
+    removeSpeaker,
+    updateSpeaker,
+    setPosition,
+    forcePosition
+
+} from '../reducer'
+import fetchAllSuccess from './__fixtures__/fetch_all_success.json'
+
+const INITIAL_STATE = reducer(undefined, {})
+
+test('has correct defaults', () => {
+    snapshot(INITIAL_STATE)
+})
+
+test('fetch all', () => {
+    snapshotReducer(reducer, INITIAL_STATE, fetchAll(fetchAllSuccess))
+})
+
+test('set Loading', () => {
+    snapshotReducer(reducer, INITIAL_STATE, setLoading(true), setLoading(false))
+})
+
+test('add speaker', () => {
+    snapshotReducer(reducer, INITIAL_STATE, addSpeaker(
+        {
+            id: 3,
+            title: "Title 3",
+            full_name: "Max Fray"
+        }
+    ))
+})
+
+test('remove speaker', () => {
+    snapshotReducer(reducer, INITIAL_STATE, removeSpeaker(3))
+})
+
+test('update speaker', () => {
+    snapshotReducer(reducer, INITIAL_STATE, updateSpeaker(
+        {
+            id: 3,
+            title: "Title 3 Update",
+            full_name: "Max Fray Update"
+        }
+    ))
+})
+
+test('set Position', () => {
+    snapshotReducer(reducer, INITIAL_STATE, setPosition({ position: 4 }))
+})
+
+test('force Position', () => {
+    snapshotReducer(reducer, INITIAL_STATE, forcePosition(
+        {
+            position: 4,
+            forcedPosition: {
+                requestId: 1,
+                time: 0,
+            }
+        }
+    ))
+})

--- a/dev/tests_setup.js
+++ b/dev/tests_setup.js
@@ -54,3 +54,8 @@ jest.mock('react-i18next', () => ({
   },
   t: str => `Translated[${str}]`
 }))
+
+/**
+ * Mock the uuid module
+ */
+jest.mock('uuid/v1', () => jest.fn(() => 'A-UNIQUE-UUID'))


### PR DESCRIPTION
I added some snapshot test for video-debate/video/reducer. 

this is the coverage reached

![image](https://user-images.githubusercontent.com/21088004/46576674-4853b680-c9a6-11e8-9d6d-8017c3311f73.png)
![image](https://user-images.githubusercontent.com/21088004/46576671-32de8c80-c9a6-11e8-8428-533bec0fe442.png)

