### PR TITLE
Add code formatting to pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,10 @@
     ]
   },
   "lint-staged": {
-    "src/**/*.{js,jsx}": [
-      "npx eslint --fix \"app/**/*.js\""
+    "app/**/*.{js,jsx}": [
+      "npx prettier --write app/**/*.{js,jsx}",
+      "npx eslint --fix \"app/**/*.js\"",
+      "git add"
     ]
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   "lint-staged": {
     "app/**/*.{js,jsx}": [
       "npx prettier --write app/**/*.{js,jsx}",
-      "npx eslint --fix \"app/**/*.js\"",
-      "git add"
+      "git add",
+      "npx eslint --fix \"app/**/*.js\""
     ]
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
   },
   "lint-staged": {
     "app/**/*.{js,jsx}": [
-      "npx prettier --write app/**/*.{js,jsx}",
+      "npx prettier --write",
       "git add",
-      "npx eslint --fix \"app/**/*.js\""
+      "npx eslint --fix"
     ]
   },
   "browserslist": {


### PR DESCRIPTION
https://github.com/CaptainFact/captain-fact/issues/68

It annoys me a bit that the prettified files are automatically included in the commit. IMHO, the process should be the same as for [`black`](https://github.com/ambv/black): if the files were edited during the hook, cancel the commit and let the user do a `git add && git commit`.