### PR TITLE
VideoDebate: Hide presence

### DIFF
--- a/app/styles/_components/VideoDebate/video_debate.sass
+++ b/app/styles/_components/VideoDebate/video_debate.sass
@@ -14,7 +14,7 @@
       flex-shrink: 1
       margin: 0 0.5em 0 0
     .presence
-      display: inline-block
+      display: none
       flex-shrink: 10000
 
   &> .tabs


### PR DESCRIPTION
Resolve https://github.com/CaptainFact/captain-fact/issues/137

Only hidden with CSS so that we can still see the info in the markup if necessary.