### PR TITLE
Defaults to browser locale, when no user preferences exists.

### DIFF
--- a/app/state/user_preferences/reducer.js
+++ b/app/state/user_preferences/reducer.js
@@ -19,7 +19,7 @@ const isMobile = window.innerWidth <= MOBILE_WIDTH_THRESHOLD
 const Preferences = new Record({
   // Disable autoscroll and sidebar expended by default on mobile
   sidebarExpended: !isMobile,
-  locale: 'en',
+  locale: browserLocale(),
   enableAutoscroll: !isMobile,
   enableSoundOnBackgroundFocus: true,
   videosLanguageFilter: null,


### PR DESCRIPTION
Addresses CaptainFact/captain-fact#140.

When the local storage doesn't contain UserPreferences, a tuple with an empty map is returned.
This tuple is then merged with the default Preferences record, which had 'en' as default rather than the browser locale.