### PR TITLE
Revert "chore(deps): bump dotenv-webpack from 1.7.0 to 3.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8557,24 +8557,24 @@
       }
     },
     "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+      "version": "6.2.0",
+      "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
     },
     "dotenv-defaults": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.1.tgz",
-      "integrity": "sha512-ugFCyBF7ILuwpmznduHPQZBMucHHJ8T4OBManTEVjemxCm2+nqifSuW2lD2SNKdiKSH1E324kZSdJ8M04b4I/A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-1.0.2.tgz",
+      "integrity": "sha512-iXFvHtXl/hZPiFj++1hBg4lbKwGM+t/GlvELDnRtOFdjXyWP7mubkVr+eZGWG62kdsbulXAef6v/j6kiWc/xGA==",
       "requires": {
-        "dotenv": "^8.2.0"
+        "dotenv": "^6.2.0"
       }
     },
     "dotenv-webpack": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-3.0.0.tgz",
-      "integrity": "sha512-HsBTgVbh9E71IdC6QcQTnAuVt11niA5QMKblcBqhVBxP975XPGMqxf21pqgVBPyRKn2GqPh5kSHMgjxeR/HEAA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.7.0.tgz",
+      "integrity": "sha1-Q4TYxX7m9AXClieMFKn5FnhW06E=",
       "requires": {
-        "dotenv-defaults": "^2.0.1"
+        "dotenv-defaults": "^1.0.2"
       }
     },
     "duplexer": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "debounce": "~1.0.2",
     "debounce-promise": "~3.1.2",
     "diff": "~4.0.2",
-    "dotenv-webpack": "~3.0.0",
+    "dotenv-webpack": "~1.7.0",
     "faker": "~4.1.0",
     "formik": "^1.4.1",
     "graphql": "~14.0.2",


### PR DESCRIPTION
Reverts CaptainFact/captain-fact-frontend#695

Resolve https://github.com/CaptainFact/captain-fact/issues/150