### PR TITLE
Notifications: Add missing user id to the query

### DIFF
--- a/app/components/App/Navbar.jsx
+++ b/app/components/App/Navbar.jsx
@@ -165,6 +165,7 @@ const Navbar = ({
                       if (loading) {
                         return <LoadingFrame size="small" />
                       } else if (error) {
+                        console.error(error)
                         return <ErrorView error={error} />
                       }
 

--- a/app/components/App/Sidebar.jsx
+++ b/app/components/App/Sidebar.jsx
@@ -156,7 +156,7 @@ export default class Sidebar extends React.PureComponent {
               return (
                 <this.MenuListLink to="/moderation" iconName="flag">
                   {t('menu.moderation')}
-                  <Tag type="danger">{pendingCount}</Tag>
+                  {Boolean(pendingCount) && <Tag type="danger">{pendingCount}</Tag>}
                 </this.MenuListLink>
               )
             }}

--- a/app/components/LoggedInUser/Notifications.jsx
+++ b/app/components/LoggedInUser/Notifications.jsx
@@ -8,6 +8,7 @@ import { withRouter } from 'react-router'
 export const loggedInUserNotificationsQuery = gql`
   query LoggedInUserNotifications($page: Int! = 1, $pageSize: Int! = 30, $filter: String = ALL) {
     loggedInUser {
+      id
       notifications(page: $page, pageSize: $pageSize, filter: $filter) {
         pageNumber
         pageSize


### PR DESCRIPTION
Fix https://github.com/CaptainFact/captain-fact/issues/154

Issue was introduced by a cache conflict with the new moderation count, because the notifications query was not properly fetching the user `id`, making the cache reconciliation impossible.

Also made a small change to hide the moderation count if there's nothing to moderate or if it's loading.