### PR TITLE
Add missing bracket & fix Phoenix Socket docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ is to use `https://styled-icons.js.org/`.
 - [React](https://reactjs.org/): View layer
 - [Redux](https://redux.js.org/): State management
 - [React Router](https://github.com/ReactTraining/react-router): Routing
-- [Phoenix](https://phoenixframework.org/): Interaction with [https://hexdocs.pm/phoenix/Phoenix.Socket.html]Phoenix.Socket)
+- [Phoenix](https://phoenixframework.org/): Interaction with [https://hexdocs.pm/phoenix/Phoenix.Socket.html](Phoenix.Socket)
 - [Bulma](https://bulma.io/): Base styles
 
 ## Linked projects


### PR DESCRIPTION
First of all, outstanding initiative! Congratulations to all involved :)

This is how the Main Libraries / Frameworks section is appearing right now:
![image](https://user-images.githubusercontent.com/357835/102466039-31508a80-402d-11eb-91f8-ce4bce722c4d.png)

This PR adds the missing `(` between the URL and the link text.