### PR TITLE
Sidebar: Hide reputation gauge when collapsed

### DIFF
--- a/app/components/App/Sidebar.jsx
+++ b/app/components/App/Sidebar.jsx
@@ -204,7 +204,7 @@ export default class Sidebar extends React.PureComponent {
 
   renderMenuProfile() {
     return (
-      <ul className="menu-list">
+      <ul className="menu-list hide-when-collapsed">
         <li>{this.renderDailyGainGauge()}</li>
       </ul>
     )


### PR DESCRIPTION
Fix an issue with the new reputation gauge that was making the menu too large when collapsed

![image](https://user-images.githubusercontent.com/1556356/105752664-dffabb80-5f47-11eb-8d0f-4ad449f1db3e.png)
