### PR TITLE
TimeSince: Parse time

### DIFF
--- a/app/components/Utils/TimeSince.jsx
+++ b/app/components/Utils/TimeSince.jsx
@@ -1,15 +1,25 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import parseISO from 'date-fns/parseISO'
 import differenceInSeconds from 'date-fns/differenceInSeconds'
 import distanceInWordsToNow from 'date-fns/formatDistanceToNow'
 import format from 'date-fns/format'
 import { locales } from '../../i18n/i18n'
 
+const getSecondsSince = (time) => {
+  if (!time) {
+    return 0
+  } else {
+    const parsedTime = typeof time === 'string' ? parseISO(time) : time
+    return !parsedTime ? 0 : differenceInSeconds(Date.now(), parsedTime)
+  }
+}
+
 @connect((state) => ({ locale: state.UserPreferences.locale }))
 export class TimeSince extends React.PureComponent {
   constructor(props) {
     super(props)
-    this.state = { minutesDiff: TimeSince.getMinutesSince(props.time) }
+    this.state = { minutesDiff: Math.trunc(getSecondsSince(props.time) / 60) }
     this.timeoutUpdate = this.timeoutUpdate.bind(this)
     this.timeout = null
   }
@@ -37,7 +47,7 @@ export class TimeSince extends React.PureComponent {
   }
 
   timeoutUpdate() {
-    const secondsSince = !this.props.time ? 0 : differenceInSeconds(Date.now(), this.props.time)
+    const secondsSince = getSecondsSince(this.props.time)
     const minutesSince = Math.trunc(secondsSince / 60)
 
     // Update state
@@ -59,9 +69,5 @@ export class TimeSince extends React.PureComponent {
       clearTimeout(this.timeout)
     }
     this.timeout = null
-  }
-
-  static getMinutesSince(time) {
-    return !time ? 0 : Math.trunc(differenceInSeconds(Date.now(), time) / 60)
   }
 }


### PR DESCRIPTION
Fix a crash in `TimeSince` related to `date-fns` update. Should resolve the `console.log` flood issue and hopefully the crash on safari.