### PR TITLE
Add message to point to the fallacy fallacy

### DIFF
--- a/app/components/Comments/CommentForm.jsx
+++ b/app/components/Comments/CommentForm.jsx
@@ -128,6 +128,11 @@ class CommentForm extends React.Component {
             </ExternalLinkNewTab>
             .
           </p>
+          {t('comment.helpFallacy')}{' '}
+          <ExternalLinkNewTab href={`https://yourlogicalfallacyis.com/${t('comment.fallacyFallacyUrl')}`}>
+            {t('comment.fallacyLink')}
+          </ExternalLinkNewTab>
+          .
         </Box>
         <ExternalLinkNewTab className="button" href="/help/contributionGuidelines">
           {t('comment.helpButton')}

--- a/app/i18n/en/videoDebate.json
+++ b/app/i18n/en/videoDebate.json
@@ -47,6 +47,9 @@
         "help3": "Sometimes, stated facts are true, but the rhetoric is fallacious or incoherent. You can alert about and specify the type of rhetological fallacies in a comment using this classification of",
         "help3Link": "errors and manipulations of rhetoric and logical thinking",
         "helpButton": "Read the contribution guidelines",
+        "helpFallacy": "However, fallacious rhetoric do not mean that facts are false",
+        "fallacyFallacyUrl": "the-fallacy-fallacy",
+        "fallacyLink": "(see here)",
         "incitateToConfirm": "No source confirming this statement yet",
         "incitateToRefute": "No source refuting this statement yet",
         "addYourSource": "Add yours"

--- a/app/i18n/en/videoDebate.json
+++ b/app/i18n/en/videoDebate.json
@@ -47,7 +47,7 @@
         "help3": "Sometimes, stated facts are true, but the rhetoric is fallacious or incoherent. You can alert about and specify the type of rhetological fallacies in a comment using this classification of",
         "help3Link": "errors and manipulations of rhetoric and logical thinking",
         "helpButton": "Read the contribution guidelines",
-        "helpFallacy": "However, fallacious rhetoric do not mean that facts are false",
+        "helpFallacy": "However, the use of rhetorical fallacies does not necessarily entail false facts",
         "fallacyFallacyUrl": "the-fallacy-fallacy",
         "fallacyLink": "(see here)",
         "incitateToConfirm": "No source confirming this statement yet",

--- a/app/i18n/fr/videoDebate.json
+++ b/app/i18n/fr/videoDebate.json
@@ -47,6 +47,9 @@
     "help3": "Parfois, les faits énoncés sont vrais, mais l’argumentation est trompeuse ou incohérente. Vous pouvez le mentionner en commentaire en indiquant le type d’argument fallacieux d’après",
     "help3Link": "la classification des erreurs et manipulations de rhétorique et de logique à ce lien",
     "helpButton": "Voir le guide de contribution",
+    "helpFallacy": "Attention cependant, un argumentaire fallacieux ne signifie pas que l'affirmation est fausse",
+    "fallacyFallacyUrl": "fr/l-erreur-sur-l-erreur",
+    "fallacyLink": "(voir ici)",
     "incitateToConfirm": "Aucune source ne confirme cette affirmation",
     "incitateToRefute": "Aucune source ne réfute cette affirmation",
     "addYourSource": "Ajouter la vôtre"


### PR DESCRIPTION
Suite a la remarque sur la discussion [:brain: Rejoignez la campagne de sensibilisation aux arguments fallacieux](https://forum.captainfact.io/t/rejoignez-la-campagne-de-sensibilisation-aux-arguments-fallacieux/751/6) je propose de rajouter un message qui met l'accent sur la possibilite de commettre [l'erreur sur l'erreur](https://yourlogicalfallacyis.com/fr/l-erreur-sur-l-erreur) en souhaitant signaler un argument fallacieux.
Seul les traductions francaises :fr: et anglaises :gb: ont ete realise ici.