### PR TITLE
Fix missing dates in multiple places

### DIFF
--- a/app/components/Utils/TimeSince.jsx
+++ b/app/components/Utils/TimeSince.jsx
@@ -37,7 +37,7 @@ export class TimeSince extends React.PureComponent {
     const { time, locale, dispatch, addSuffix = true, isDateTime = true, ...props } = this.props
     const localeObj = locales[locale]
     const dateFormat = isDateTime ? localeObj.defaultDateTimeFormat : localeObj.defaultDateFormat
-    const timeAsDate = time
+    const timeAsDate = typeof time === 'string' ? parseISO(time) : time
 
     if (!timeAsDate || !isFinite(timeAsDate)) {
       return null

--- a/app/components/Utils/TimeSince.jsx
+++ b/app/components/Utils/TimeSince.jsx
@@ -37,7 +37,8 @@ export class TimeSince extends React.PureComponent {
     const { time, locale, dispatch, addSuffix = true, isDateTime = true, ...props } = this.props
     const localeObj = locales[locale]
     const dateFormat = isDateTime ? localeObj.defaultDateTimeFormat : localeObj.defaultDateFormat
-    const timeAsDate = time && parseISO(time)
+    const timeAsDate = time
+
     if (!timeAsDate || !isFinite(timeAsDate)) {
       return null
     }


### PR DESCRIPTION
Voir https://forum.captainfact.io/t/les-dates-et-heures-ne-sont-plus-affiches/821

Les dates n'etaient plus affiche sur les commentaires et dans l'espace utilisateur du a a l'echec de la fonction `parseISO` sur la variable `time`.
En effet cette derniere est deja une `Date` ce qui fait echoue `parseISO`.
Je n'ai pas reussit a trouver quand la variable `time` est passe d'une `String` a une `Date`.