### PR TITLE
Prevent diff-view to expand beyond a user-action card

### DIFF
--- a/app/styles/_components/UsersActions/user_action.sass
+++ b/app/styles/_components/UsersActions/user_action.sass
@@ -26,6 +26,7 @@
       color: orange
       vertical-align: top
     .diff-view
+      max-width: 100%
       display: inline-block
       padding: 0
       background: none


### PR DESCRIPTION
On chrome-like engine the content of an element of class 'diff-entry' could
expand beyond its parent 'user-action card'.

Fix https://github.com/CaptainFact/captain-fact/issues/172