### PR TITLE
Improve link contrast on hover

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .git
 .github
 .idea
+.vscode
 .eslintrc.yml
 .gitignore
 .sass-lint.yml

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .DS_Store
 .cache
 .project
+.vscode
 .settings
 .tmproj
 nbproject

--- a/app/styles/_global/variables.sass
+++ b/app/styles/_global/variables.sass
@@ -77,7 +77,7 @@ $link: $primary
 $link-invert: $primary-invert
 $link-visited: $purple
 
-$link-hover: lighten($primary, 25)
+$link-hover: darken($primary, 25)
 $link-hover-border: $grey-light !default
 
 $link-focus: $grey-darker


### PR DESCRIPTION
J'ai trouvé que les liens au survol manquaient pas de mal de contraste et étaient à peine visible. 
Même si mon écran est sans doûte mal calibré je pense que ça peut améliorer la lisibilité pour d'autres que moi. 
J'ai simplement inversé le contraste de 25% plus clair à 25% plus foncé. 
Qu'en pensez-vous ?

## Menu

Avant 
![menu_hover_before](https://user-images.githubusercontent.com/571235/112483699-94169800-8d79-11eb-8e66-070ae0641ff3.png)

Après
![menu_hover_after](https://user-images.githubusercontent.com/571235/112483713-95e05b80-8d79-11eb-8e7f-c6eb3592ccd5.png)

## Vidéo

Avant
![hover_guest_before](https://user-images.githubusercontent.com/571235/112484271-143cfd80-8d7a-11eb-954a-03d52cfa3def.png)

Après
![hover_guest_after](https://user-images.githubusercontent.com/571235/112484299-1b640b80-8d7a-11eb-86c5-f35e7d0e60dc.png)

## Page d'aide

Avant
![hover_help_before](https://user-images.githubusercontent.com/571235/112484205-05eee180-8d7a-11eb-9f08-78dfed0f9d36.png)

Après
![hover_help_after](https://user-images.githubusercontent.com/571235/112484229-09826880-8d7a-11eb-87d7-fa035811d9b8.png)
