### PR TITLE
feat(Navbar): toggle Menu icon to X icon on mobile

### DIFF
--- a/app/components/App/MenuToggleSwitch.jsx
+++ b/app/components/App/MenuToggleSwitch.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import styled, { withTheme } from 'styled-components'
+import { themeGet } from 'styled-system'
+import { Menu as MenuIcon } from 'styled-icons/boxicons-regular/Menu'
+import { X as XIcon } from 'styled-icons/boxicons-regular/X'
+
+import { toggleSidebar } from '../../state/user_preferences/reducer'
+
+const Button = styled.button`
+  background: none;
+  outline: none;
+  border: 0;
+  padding: 0;
+  height: 100%;
+  width: 45px;
+  cursor: pointer;
+  user-select: none;
+  color: ${themeGet('colors.black.400')};
+
+  &:hover {
+    color: ${themeGet('colors.black.500')};
+  }
+`
+
+const MenuToggleSwitch = ({ toggleSidebar, sidebarExpended, toggleableIcon }) => (
+  <Button onClick={() => toggleSidebar()}>
+    {sidebarExpended && toggleableIcon ? <XIcon /> : <MenuIcon />}
+  </Button>
+)
+
+MenuToggleSwitch.propTypes = {
+  toggleSidebar: PropTypes.func.isRequired,
+  sidebarExpended: PropTypes.bool.isRequired,
+  toggleableIcon: PropTypes.bool.isRequired,
+}
+
+export default withTheme(
+  connect(({ UserPreferences: { sidebarExpended } }) => ({ sidebarExpended }), { toggleSidebar })(
+    MenuToggleSwitch
+  )
+)

--- a/app/components/App/Navbar.jsx
+++ b/app/components/App/Navbar.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { connect } from 'react-redux'
 import { Link, withRouter } from 'react-router'
 import styled, { withTheme, css } from 'styled-components'
 import { Flex, Box } from '@rebass/grid'
@@ -9,14 +8,12 @@ import Popup from 'reactjs-popup'
 import { withNamespaces } from 'react-i18next'
 import { omit } from 'lodash'
 
-import { Menu } from 'styled-icons/boxicons-regular/Menu'
-
 import { CaretDown } from 'styled-icons/fa-solid/CaretDown'
 import { UserCircle } from 'styled-icons/fa-regular/UserCircle'
 import { HelpCircle } from 'styled-icons/boxicons-regular/HelpCircle'
 
 import Logo from './Logo'
-import { toggleSidebar } from '../../state/user_preferences/reducer'
+import MenuToggleSwitch from './MenuToggleSwitch'
 import UserPicture from '../Users/UserPicture'
 import { USER_PICTURE_LARGE } from '../../constants'
 import { withLoggedInUser } from '../LoggedInUser/UserProvider'
@@ -97,17 +94,6 @@ const UserLoading = styled(UserCircle)`
   margin-right: ${themeGet('space.2')};
 `
 
-const MenuToggleSwitch = styled(Menu)`
-  height: 100%;
-  width: 45px;
-  cursor: pointer;
-  user-select: none;
-
-  &:hover {
-    color: ${themeGet('colors.black.500')};
-  }
-`
-
 const basePopupStyle = {
   boxShadow: 'rgba(150, 150, 150, 0.2) 5px 10px 15px -6px',
   filter: 'none',
@@ -120,7 +106,6 @@ const mobilePopupStyle = { ...basePopupStyle, width: '95%' }
 const Navbar = ({
   t,
   theme,
-  toggleSidebar,
   loggedInUser,
   isAuthenticated,
   loggedInUserLoading,
@@ -140,7 +125,8 @@ const Navbar = ({
         {/* Left */}
         <Flex alignItems="center">
           <Container display="flex" alignItems="center" height={theme.navbarHeight - 1}>
-            <MenuToggleSwitch onClick={() => toggleSidebar()} />
+            {/* Show X icon only on small device */}
+            <MenuToggleSwitch toggleableIcon={width <= 768} />
             {width >= 425 && (
               <StyledLink className="logo" to="/" ml={1}>
                 <Logo height={theme.navbarHeight - 24} borderless />
@@ -249,7 +235,5 @@ const Navbar = ({
 }
 
 export default withTheme(
-  connect(null, { toggleSidebar })(
-    withLoggedInUser(withNamespaces('main')(withRouter(withResizeDetector(Navbar))))
-  )
+  withLoggedInUser(withNamespaces('main')(withRouter(withResizeDetector(Navbar))))
 )


### PR DESCRIPTION
J'ai trouvé un peu déroutant que l'icône du menu ne change pas d'état quand le menu est ouvert en mobile.
En desktop j'ai laissé tel quel, l'action n'était pas la même (fermer vs réduire le menu) et avoir une croix quand on arrive sur la page si le menu est ouvert ne rend pas très bien.

Qu'en pensez-vous ?

![toggle](https://user-images.githubusercontent.com/571235/112496440-0771d700-8d85-11eb-92e9-2e8498833d81.gif)
