### PR TITLE
update user : default display is now activity user page

### DIFF
--- a/app/components/Users/UserMenu.jsx
+++ b/app/components/Users/UserMenu.jsx
@@ -12,9 +12,9 @@ import { Videos } from 'styled-icons/boxicons-solid'
 import { LogOut } from 'styled-icons/feather'
 
 const BASE_LINKS = [
-  { path: '', i18nKey: 'menu.profile', Icon: UserCircle },
+  { path: '', i18nKey: 'menu.activity', Icon: Activity },
   { path: '/videos', i18nKey: 'menu.addedVideos', Icon: Videos },
-  { path: '/activity', i18nKey: 'menu.activity', Icon: Activity },
+  { path: '/profile', i18nKey: 'menu.profile', Icon: UserCircle },
 ]
 
 const AUTHENTICATED_LINKS = [

--- a/app/router.jsx
+++ b/app/router.jsx
@@ -44,8 +44,8 @@ const CFRouter = () => (
       <Route path="/reset_password/confirm/:token" component={ResetPasswordConfirmForm} />
       <Route path="/newsletter/unsubscribe/:token" component={NewsletterSubscription} />
       <Route path="/u/:username" component={User}>
-        <IndexRoute component={UserProfile} />
-        <Route path="/u/:username/activity" component={ActivityLog} />
+        <IndexRoute component={ActivityLog} />
+        <Route path="/u/:username/profile" component={UserProfile} />
         <Route path="/u/:username/settings" component={UserSettings} />
         <Route path="/u/:username/videos" component={UserAddedVideos} />
         <Route path="/u/:username/subscriptions" component={SubscriptionsPage} />


### PR DESCRIPTION
Related issue : https://github.com/CaptainFact/captain-fact/issues/218

> Aujourd'hui, cliquer sur le pseudo d'un utilisateur mène sur son profil avec les médailles.
> Les médailles ne sont pas les infos les plus pertinentes au sujet de l'utilisateur.
> Il est proposé d'inverser "profil" (médailles) par "activité", afin que la page du profil utilisateur commence par ses activités.