### PR TITLE
Remove docker from E2E CI configuration

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,28 +7,72 @@ env:
 
 jobs:
   cypress:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # Remember to update this when changing Erlang version. See https://github.com/erlef/setup-beam
+    services:
+      db:
+        image: captainfact/dev-db:latest
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v3
+      # Checkout
+      - name: Checkout API
+        uses: actions/checkout@v3
         with:
-          node-version-file: '.tool-versions'
-          cache: 'npm'
-      - name: Cache Cypress Binary
-        id: cache-cypress-binary
+          repository: CaptainFact/captain-fact-api
+          ref: refs/heads/staging
+          path: api
+      - name: Checkout Frontend
+        uses: actions/checkout@v2
+        with:
+          repository: CaptainFact/captain-fact-frontend
+          path: frontend
+      # Setup API
+      - name: Restore Elixir cache
         uses: actions/cache@v3
         with:
-          path: ~/.cache/Cypress
-          key: ${{ runner.os }}-cypress-binary-${{ hashFiles('package-lock.json') }}
-      - name: Install dependencies
-        run: npm ci
-      - name: Start local API
-        run: docker-compose up -d
-      - name: Start Frontend
-        run: npm start &
-      - name: Waiting for Frontend to be ready
-        run: until curl -s localhost:3333 > /dev/null; do sleep 1; done
-      - name: Waiting for API to be ready
-        run: until curl localhost:4000; do sleep 1; done
-      - name: Run tests
-        run: npm run cypress
+          path: ./api/deps
+          key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ env.cache-name }}-
+            ${{ runner.os }}-mix-
+      - name: Restore Elixir build folder
+        uses: actions/cache@v1
+        with:
+          path: ./api/build
+          key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ env.cache-name }}-
+            ${{ runner.os }}-mix-
+      - uses: erlef/setup-beam@v1
+        with:
+          version-file: ./api/.tool-versions
+          version-type: strict
+      - name: Install API's dependencies
+        working-directory: api
+        run: mix deps.get
+      - name: Compile dependencies
+        working-directory: api
+        run: mix deps.compile
+      - name: Compile project
+        working-directory: api
+        run: mix compile
+      - name: Prepare DB
+        working-directory: api
+        run: mix ecto.create && mix ecto.migrate
+      # Setup Frontend
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: './frontend/.tool-versions'
+          cache-dependency-path: './frontend/package-lock.json'
+          cache: 'npm'
+      - name: Install Frontend's dependencies
+        working-directory: frontend
+        run: npm ci --prefer-offline --no-audit
+      # Run tests
+      - name: Start E2E tests
+        working-directory: api
+        run: ./scripts/run_e2e_ci.sh


### PR DESCRIPTION
Align with https://github.com/CaptainFact/captain-fact-api/pull/392 and stop relying on Docker. For https://github.com/CaptainFact/captain-fact-api/pull/399.