### PR TITLE
Sync notification volume with video player

### DIFF
--- a/app/components/App/BackgroundNotifier.jsx
+++ b/app/components/App/BackgroundNotifier.jsx
@@ -12,7 +12,6 @@ import { isStatementConfirmed } from '../../lib/statements_utils'
 const confirmAudioFile = new Audio(confirmSoundFileURL)
 const refuteAudioFile = new Audio(refuteSoundFileURL)
 const neutralAudioFile = new Audio(neutralSoundFileURL)
-const notificationAudioFiles = [confirmAudioFile, refuteAudioFile, neutralAudioFile]
 
 const setFavicon = (value) => {
   // Reset favicon URL each time we interact with it to fix ugly background
@@ -40,6 +39,14 @@ const BackgroundNotifier = () => {
     setFavicon(null)
   }, [])
 
+  const playNotification = useCallback(
+    (audioFile) => {
+      audioFile.volume = volume
+      audioFile.play()
+    },
+    [volume],
+  )
+
   // Initialize Tinycon options
   useEffect(() => {
     Tinycon.setOptions({
@@ -47,12 +54,6 @@ const BackgroundNotifier = () => {
       fallback: false,
     })
   }, [])
-
-  useEffect(() => {
-    notificationAudioFiles.forEach((audioFile) => {
-      audioFile.volume = volume
-    })
-  }, [volume])
 
   // Handle focus event listener
   useEffect(() => {
@@ -68,7 +69,7 @@ const BackgroundNotifier = () => {
   useEffect(() => {
     // Play a sound when enabling setting
     if (!prevSoundEnabledRef.current && soundEnabled) {
-      neutralAudioFile.play()
+      playNotification(neutralAudioFile)
       prevSoundEnabledRef.current = soundEnabled
       return
     }
@@ -89,18 +90,18 @@ const BackgroundNotifier = () => {
       if (soundEnabled) {
         const confirmed = isStatementConfirmed(comments)
         if (confirmed === null) {
-          neutralAudioFile.play()
+          playNotification(neutralAudioFile)
         } else if (confirmed) {
-          confirmAudioFile.play()
+          playNotification(confirmAudioFile)
         } else {
-          refuteAudioFile.play()
+          playNotification(refuteAudioFile)
         }
       }
     }
 
     // Always update the ref at the end
     prevFocusedStatementIdRef.current = focusedStatementId
-  }, [focusedStatementId, soundEnabled, comments, setFavicon])
+  }, [focusedStatementId, soundEnabled, comments, playNotification])
 
   return null
 }

--- a/app/components/App/BackgroundNotifier.jsx
+++ b/app/components/App/BackgroundNotifier.jsx
@@ -6,11 +6,13 @@ import neutralSoundFileURL from '../../assets/sounds/background_statement_neutra
 import refuteSoundFileURL from '../../assets/sounds/background_statement_refute.mp3'
 import { useFocusedStatement } from '../../contexts/FocusedStatementContext'
 import { useUserPreferences } from '../../contexts/UserPreferencesContext'
+import { useVideoPlayback } from '../../contexts/VideoPlaybackContext'
 import { isStatementConfirmed } from '../../lib/statements_utils'
 
 const confirmAudioFile = new Audio(confirmSoundFileURL)
 const refuteAudioFile = new Audio(refuteSoundFileURL)
 const neutralAudioFile = new Audio(neutralSoundFileURL)
+const notificationAudioFiles = [confirmAudioFile, refuteAudioFile, neutralAudioFile]
 
 const setFavicon = (value) => {
   // Reset favicon URL each time we interact with it to fix ugly background
@@ -27,6 +29,7 @@ const setFavicon = (value) => {
 const BackgroundNotifier = () => {
   const { statement } = useFocusedStatement()
   const { enableSoundOnBackgroundFocus: soundEnabled } = useUserPreferences()
+  const { volume } = useVideoPlayback()
   const prevFocusedStatementIdRef = useRef(-1)
   const prevSoundEnabledRef = useRef(soundEnabled)
 
@@ -44,6 +47,12 @@ const BackgroundNotifier = () => {
       fallback: false,
     })
   }, [])
+
+  useEffect(() => {
+    notificationAudioFiles.forEach((audioFile) => {
+      audioFile.volume = volume
+    })
+  }, [volume])
 
   // Handle focus event listener
   useEffect(() => {

--- a/app/components/VideoDebate/VideoDebatePlayer.jsx
+++ b/app/components/VideoDebate/VideoDebatePlayer.jsx
@@ -8,7 +8,7 @@ import { useVideoPlayback } from '../../contexts/VideoPlaybackContext'
  * Updates position when playing and seeks to position when requested.
  */
 const VideoDebatePlayer = ({ url }) => {
-  const { forcedPosition, isPlaying, setPosition, setPlaying } = useVideoPlayback()
+  const { forcedPosition, isPlaying, setPosition, setPlaying, setVolume } = useVideoPlayback()
   const playerRef = useRef(null)
   const prevForcedPositionRef = useRef(null)
 
@@ -33,6 +33,7 @@ const VideoDebatePlayer = ({ url }) => {
       onPlay={() => setPlaying(true)}
       onPause={() => setPlaying(false)}
       onProgress={({ playedSeconds }) => setPosition(playedSeconds)}
+      onVolumeChange={(event) => setVolume(event.target.volume)}
       width=""
       height=""
       controls

--- a/app/components/VideoDebate/VideoDebatePlayer.jsx
+++ b/app/components/VideoDebate/VideoDebatePlayer.jsx
@@ -1,7 +1,36 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import ReactPlayer from 'react-player'
 
 import { useVideoPlayback } from '../../contexts/VideoPlaybackContext'
+
+const VOLUME_SYNC_INTERVAL = 2000
+
+export const readInternalPlayerVolume = (player) => {
+  if (!player) {
+    return null
+  }
+
+  if (typeof player.isMuted === 'function' && player.isMuted()) {
+    return 0
+  }
+
+  if (player.muted === true) {
+    return 0
+  }
+
+  if (typeof player.getVolume === 'function') {
+    const volume = player.getVolume()
+    if (typeof volume === 'number' && !Number.isNaN(volume)) {
+      return volume > 1 ? volume / 100 : volume
+    }
+  }
+
+  if (typeof player.volume === 'number' && !Number.isNaN(player.volume)) {
+    return player.volume
+  }
+
+  return null
+}
 
 /**
  * A player component with local state for position/playing.
@@ -11,6 +40,20 @@ const VideoDebatePlayer = ({ url }) => {
   const { forcedPosition, isPlaying, setPosition, setPlaying, setVolume } = useVideoPlayback()
   const playerRef = useRef(null)
   const prevForcedPositionRef = useRef(null)
+
+  const syncPlayerVolume = useCallback(() => {
+    const player = playerRef.current?.getInternalPlayer?.()
+    const volume = readInternalPlayerVolume(player)
+
+    if (volume !== null) {
+      setVolume(volume)
+    }
+  }, [setVolume])
+
+  useEffect(() => {
+    const intervalId = window.setInterval(syncPlayerVolume, VOLUME_SYNC_INTERVAL)
+    return () => window.clearInterval(intervalId)
+  }, [syncPlayerVolume])
 
   useEffect(() => {
     if (
@@ -30,10 +73,19 @@ const VideoDebatePlayer = ({ url }) => {
       className="w-full aspect-video"
       url={url}
       playing={isPlaying}
-      onPlay={() => setPlaying(true)}
-      onPause={() => setPlaying(false)}
-      onProgress={({ playedSeconds }) => setPosition(playedSeconds)}
-      onVolumeChange={(event) => setVolume(event.target.volume)}
+      onReady={syncPlayerVolume}
+      onPlay={() => {
+        setPlaying(true)
+        syncPlayerVolume()
+      }}
+      onPause={() => {
+        setPlaying(false)
+        syncPlayerVolume()
+      }}
+      onProgress={({ playedSeconds }) => {
+        setPosition(playedSeconds)
+        syncPlayerVolume()
+      }}
       width=""
       height=""
       controls

--- a/app/components/VideoDebate/__tests__/VideoDebatePlayer.spec.jsx
+++ b/app/components/VideoDebate/__tests__/VideoDebatePlayer.spec.jsx
@@ -1,0 +1,19 @@
+import { readInternalPlayerVolume } from '../VideoDebatePlayer'
+
+describe('readInternalPlayerVolume', () => {
+  it('returns null when no volume is available', () => {
+    expect(readInternalPlayerVolume(null)).toBeNull()
+    expect(readInternalPlayerVolume({})).toBeNull()
+  })
+
+  it('returns zero for muted players', () => {
+    expect(readInternalPlayerVolume({ isMuted: () => true, getVolume: () => 50 })).toBe(0)
+    expect(readInternalPlayerVolume({ muted: true, volume: 0.5 })).toBe(0)
+  })
+
+  it('normalizes provider volume ranges', () => {
+    expect(readInternalPlayerVolume({ getVolume: () => 42 })).toBe(0.42)
+    expect(readInternalPlayerVolume({ getVolume: () => 0.5 })).toBe(0.5)
+    expect(readInternalPlayerVolume({ volume: 0.25 })).toBe(0.25)
+  })
+})

--- a/app/contexts/VideoPlaybackContext.jsx
+++ b/app/contexts/VideoPlaybackContext.jsx
@@ -3,8 +3,8 @@ import React, { createContext, useCallback, useContext, useMemo, useReducer, use
 const initialState = {
   position: 0,
   isPlaying: false,
-  volume: 1,
   forcedPosition: { requestId: null, time: 0 },
+  volume: 1,
 }
 
 const playbackReducer = (state, action) => {
@@ -63,7 +63,11 @@ export const VideoPlaybackProvider = ({ children, onUpdatePosition }) => {
   }, [])
 
   const setVolume = useCallback((volume) => {
-    dispatch({ type: 'SET_VOLUME', payload: volume })
+    if (typeof volume !== 'number' || Number.isNaN(volume)) {
+      return
+    }
+
+    dispatch({ type: 'SET_VOLUME', payload: Math.min(1, Math.max(0, volume)) })
   }, [])
 
   const forcePosition = useCallback((time) => {
@@ -74,22 +78,22 @@ export const VideoPlaybackProvider = ({ children, onUpdatePosition }) => {
     () => ({
       position: state.position,
       isPlaying: state.isPlaying,
-      volume: state.volume,
       forcedPosition: state.forcedPosition,
+      volume: state.volume,
       setPosition,
       setPlaying,
-      setVolume,
       forcePosition,
+      setVolume,
     }),
     [
       state.position,
       state.isPlaying,
-      state.volume,
       state.forcedPosition,
+      state.volume,
       setPosition,
       setPlaying,
-      setVolume,
       forcePosition,
+      setVolume,
     ],
   )
 

--- a/app/contexts/VideoPlaybackContext.jsx
+++ b/app/contexts/VideoPlaybackContext.jsx
@@ -3,6 +3,7 @@ import React, { createContext, useCallback, useContext, useMemo, useReducer, use
 const initialState = {
   position: 0,
   isPlaying: false,
+  volume: 1,
   forcedPosition: { requestId: null, time: 0 },
 }
 
@@ -17,6 +18,11 @@ const playbackReducer = (state, action) => {
       return {
         ...state,
         isPlaying: action.payload,
+      }
+    case 'SET_VOLUME':
+      return {
+        ...state,
+        volume: action.payload,
       }
     case 'FORCE_POSITION':
       return {
@@ -56,6 +62,10 @@ export const VideoPlaybackProvider = ({ children, onUpdatePosition }) => {
     dispatch({ type: 'SET_PLAYING', payload: isPlaying })
   }, [])
 
+  const setVolume = useCallback((volume) => {
+    dispatch({ type: 'SET_VOLUME', payload: volume })
+  }, [])
+
   const forcePosition = useCallback((time) => {
     dispatch({ type: 'FORCE_POSITION', payload: time })
   }, [])
@@ -64,12 +74,23 @@ export const VideoPlaybackProvider = ({ children, onUpdatePosition }) => {
     () => ({
       position: state.position,
       isPlaying: state.isPlaying,
+      volume: state.volume,
       forcedPosition: state.forcedPosition,
       setPosition,
       setPlaying,
+      setVolume,
       forcePosition,
     }),
-    [state.position, state.isPlaying, state.forcedPosition, setPosition, setPlaying, forcePosition],
+    [
+      state.position,
+      state.isPlaying,
+      state.volume,
+      state.forcedPosition,
+      setPosition,
+      setPlaying,
+      setVolume,
+      forcePosition,
+    ],
   )
 
   return <VideoPlaybackContext.Provider value={value}>{children}</VideoPlaybackContext.Provider>


### PR DESCRIPTION
## Summary
- track the ReactPlayer volume in VideoPlaybackContext
- apply the current video volume to background notification sounds

Fixes CaptainFact/captain-fact#93

## Test plan
- npx eslint app/contexts/VideoPlaybackContext.jsx app/components/VideoDebate/VideoDebatePlayer.jsx app/components/App/BackgroundNotifier.jsx
- git diff --check
- npm test -- --passWithNoTests --runTestsByPath app/contexts/VideoPlaybackContext.jsx app/components/VideoDebate/VideoDebatePlayer.jsx app/components/App/BackgroundNotifier.jsx --watchAll=false