### PR TITLE
Sync background notification volume with video player

### DIFF
--- a/app/components/App/BackgroundNotifier.jsx
+++ b/app/components/App/BackgroundNotifier.jsx
@@ -6,6 +6,7 @@ import neutralSoundFileURL from '../../assets/sounds/background_statement_neutra
 import refuteSoundFileURL from '../../assets/sounds/background_statement_refute.mp3'
 import { useFocusedStatement } from '../../contexts/FocusedStatementContext'
 import { useUserPreferences } from '../../contexts/UserPreferencesContext'
+import { useVideoPlayback } from '../../contexts/VideoPlaybackContext'
 import { isStatementConfirmed } from '../../lib/statements_utils'
 
 const confirmAudioFile = new Audio(confirmSoundFileURL)
@@ -27,6 +28,7 @@ const setFavicon = (value) => {
 const BackgroundNotifier = () => {
   const { statement } = useFocusedStatement()
   const { enableSoundOnBackgroundFocus: soundEnabled } = useUserPreferences()
+  const { volume } = useVideoPlayback()
   const prevFocusedStatementIdRef = useRef(-1)
   const prevSoundEnabledRef = useRef(soundEnabled)
 
@@ -36,6 +38,14 @@ const BackgroundNotifier = () => {
   const onFocus = useCallback(() => {
     setFavicon(null)
   }, [])
+
+  const playNotification = useCallback(
+    (audioFile) => {
+      audioFile.volume = volume
+      audioFile.play()
+    },
+    [volume],
+  )
 
   // Initialize Tinycon options
   useEffect(() => {
@@ -59,7 +69,7 @@ const BackgroundNotifier = () => {
   useEffect(() => {
     // Play a sound when enabling setting
     if (!prevSoundEnabledRef.current && soundEnabled) {
-      neutralAudioFile.play()
+      playNotification(neutralAudioFile)
       prevSoundEnabledRef.current = soundEnabled
       return
     }
@@ -80,18 +90,18 @@ const BackgroundNotifier = () => {
       if (soundEnabled) {
         const confirmed = isStatementConfirmed(comments)
         if (confirmed === null) {
-          neutralAudioFile.play()
+          playNotification(neutralAudioFile)
         } else if (confirmed) {
-          confirmAudioFile.play()
+          playNotification(confirmAudioFile)
         } else {
-          refuteAudioFile.play()
+          playNotification(refuteAudioFile)
         }
       }
     }
 
     // Always update the ref at the end
     prevFocusedStatementIdRef.current = focusedStatementId
-  }, [focusedStatementId, soundEnabled, comments, setFavicon])
+  }, [focusedStatementId, soundEnabled, comments, playNotification])
 
   return null
 }

--- a/app/components/VideoDebate/VideoDebatePlayer.jsx
+++ b/app/components/VideoDebate/VideoDebatePlayer.jsx
@@ -1,16 +1,59 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import ReactPlayer from 'react-player'
 
 import { useVideoPlayback } from '../../contexts/VideoPlaybackContext'
+
+const VOLUME_SYNC_INTERVAL_MS = 2000
+
+export const getInternalPlayerVolume = (player) => {
+  if (!player) {
+    return null
+  }
+
+  if (typeof player.isMuted === 'function' && player.isMuted()) {
+    return 0
+  }
+
+  if (player.muted) {
+    return 0
+  }
+
+  if (typeof player.getVolume === 'function') {
+    const volume = player.getVolume()
+    if (typeof volume === 'number' && !Number.isNaN(volume)) {
+      return volume > 1 ? volume / 100 : volume
+    }
+  }
+
+  if (typeof player.volume === 'number' && !Number.isNaN(player.volume)) {
+    return player.volume
+  }
+
+  return null
+}
 
 /**
  * A player component with local state for position/playing.
  * Updates position when playing and seeks to position when requested.
  */
 const VideoDebatePlayer = ({ url }) => {
-  const { forcedPosition, isPlaying, setPosition, setPlaying } = useVideoPlayback()
+  const { forcedPosition, isPlaying, setPosition, setPlaying, setVolume } = useVideoPlayback()
   const playerRef = useRef(null)
   const prevForcedPositionRef = useRef(null)
+
+  const syncPlayerVolume = useCallback(() => {
+    const player = playerRef.current?.getInternalPlayer?.()
+    const volume = getInternalPlayerVolume(player)
+
+    if (volume !== null) {
+      setVolume(volume)
+    }
+  }, [setVolume])
+
+  useEffect(() => {
+    const intervalId = window.setInterval(syncPlayerVolume, VOLUME_SYNC_INTERVAL_MS)
+    return () => window.clearInterval(intervalId)
+  }, [syncPlayerVolume])
 
   useEffect(() => {
     if (
@@ -30,9 +73,19 @@ const VideoDebatePlayer = ({ url }) => {
       className="w-full aspect-video"
       url={url}
       playing={isPlaying}
-      onPlay={() => setPlaying(true)}
-      onPause={() => setPlaying(false)}
-      onProgress={({ playedSeconds }) => setPosition(playedSeconds)}
+      onReady={syncPlayerVolume}
+      onPlay={() => {
+        setPlaying(true)
+        syncPlayerVolume()
+      }}
+      onPause={() => {
+        setPlaying(false)
+        syncPlayerVolume()
+      }}
+      onProgress={({ playedSeconds }) => {
+        setPosition(playedSeconds)
+        syncPlayerVolume()
+      }}
       width=""
       height=""
       controls

--- a/app/components/VideoDebate/__tests__/VideoDebatePlayer.spec.jsx
+++ b/app/components/VideoDebate/__tests__/VideoDebatePlayer.spec.jsx
@@ -1,0 +1,19 @@
+import { getInternalPlayerVolume } from '../VideoDebatePlayer'
+
+describe('getInternalPlayerVolume', () => {
+  it('returns null when no readable volume is available', () => {
+    expect(getInternalPlayerVolume(null)).toBeNull()
+    expect(getInternalPlayerVolume({})).toBeNull()
+  })
+
+  it('returns zero when the internal player is muted', () => {
+    expect(getInternalPlayerVolume({ isMuted: () => true, getVolume: () => 50 })).toBe(0)
+    expect(getInternalPlayerVolume({ muted: true, volume: 0.5 })).toBe(0)
+  })
+
+  it('normalizes provider volume ranges', () => {
+    expect(getInternalPlayerVolume({ getVolume: () => 42 })).toBe(0.42)
+    expect(getInternalPlayerVolume({ getVolume: () => 0.5 })).toBe(0.5)
+    expect(getInternalPlayerVolume({ volume: 0.25 })).toBe(0.25)
+  })
+})

--- a/app/contexts/VideoPlaybackContext.jsx
+++ b/app/contexts/VideoPlaybackContext.jsx
@@ -4,6 +4,7 @@ const initialState = {
   position: 0,
   isPlaying: false,
   forcedPosition: { requestId: null, time: 0 },
+  volume: 1,
 }
 
 const playbackReducer = (state, action) => {
@@ -22,6 +23,11 @@ const playbackReducer = (state, action) => {
       return {
         ...state,
         forcedPosition: { requestId: Date.now(), time: action.payload },
+      }
+    case 'SET_VOLUME':
+      return {
+        ...state,
+        volume: action.payload,
       }
     default:
       return state
@@ -60,16 +66,35 @@ export const VideoPlaybackProvider = ({ children, onUpdatePosition }) => {
     dispatch({ type: 'FORCE_POSITION', payload: time })
   }, [])
 
+  const setVolume = useCallback((volume) => {
+    if (typeof volume !== 'number' || Number.isNaN(volume)) {
+      return
+    }
+
+    dispatch({ type: 'SET_VOLUME', payload: Math.min(1, Math.max(0, volume)) })
+  }, [])
+
   const value = useMemo(
     () => ({
       position: state.position,
       isPlaying: state.isPlaying,
       forcedPosition: state.forcedPosition,
+      volume: state.volume,
       setPosition,
       setPlaying,
       forcePosition,
+      setVolume,
     }),
-    [state.position, state.isPlaying, state.forcedPosition, setPosition, setPlaying, forcePosition],
+    [
+      state.position,
+      state.isPlaying,
+      state.forcedPosition,
+      state.volume,
+      setPosition,
+      setPlaying,
+      forcePosition,
+      setVolume,
+    ],
   )
 
   return <VideoPlaybackContext.Provider value={value}>{children}</VideoPlaybackContext.Provider>


### PR DESCRIPTION
Fixes CaptainFact/captain-fact#93.\n\n## Summary\n- stores the current video volume in VideoPlaybackContext\n- reads the actual internal player volume/muted state instead of relying on an unsupported ReactPlayer wrapper callback\n- applies the stored volume before playing confirm, refute, and neutral background notification sounds\n- adds unit coverage for internal player volume normalization\n\n## Verification\n- npm test -- --runInBand\n- npx eslint app/contexts/VideoPlaybackContext.jsx app/components/VideoDebate/VideoDebatePlayer.jsx app/components/VideoDebate/__tests__/VideoDebatePlayer.spec.jsx app/components/App/BackgroundNotifier.jsx\n- npx prettier --check app/contexts/VideoPlaybackContext.jsx app/components/VideoDebate/VideoDebatePlayer.jsx app/components/VideoDebate/__tests__/VideoDebatePlayer.spec.jsx app/components/App/BackgroundNotifier.jsx\n- npm run build