### PR TITLE
Scale background notification sounds with player volume

### DIFF
--- a/app/components/App/BackgroundNotifier.jsx
+++ b/app/components/App/BackgroundNotifier.jsx
@@ -6,6 +6,7 @@ import neutralSoundFileURL from '../../assets/sounds/background_statement_neutra
 import refuteSoundFileURL from '../../assets/sounds/background_statement_refute.mp3'
 import { useFocusedStatement } from '../../contexts/FocusedStatementContext'
 import { useUserPreferences } from '../../contexts/UserPreferencesContext'
+import { useVideoPlayback } from '../../contexts/VideoPlaybackContext'
 import { isStatementConfirmed } from '../../lib/statements_utils'
 
 const confirmAudioFile = new Audio(confirmSoundFileURL)
@@ -19,6 +20,11 @@ const setFavicon = (value) => {
   Tinycon.setBubble(value)
 }
 
+const playNotificationSound = (audioFile, volume) => {
+  audioFile.volume = volume
+  audioFile.play()
+}
+
 /**
  * This component watches for various events then triggers sounds or change
  * favicon to notify the user that there's something to look at **only**
@@ -27,6 +33,7 @@ const setFavicon = (value) => {
 const BackgroundNotifier = () => {
   const { statement } = useFocusedStatement()
   const { enableSoundOnBackgroundFocus: soundEnabled } = useUserPreferences()
+  const { volume } = useVideoPlayback()
   const prevFocusedStatementIdRef = useRef(-1)
   const prevSoundEnabledRef = useRef(soundEnabled)
 
@@ -59,7 +66,7 @@ const BackgroundNotifier = () => {
   useEffect(() => {
     // Play a sound when enabling setting
     if (!prevSoundEnabledRef.current && soundEnabled) {
-      neutralAudioFile.play()
+      playNotificationSound(neutralAudioFile, volume)
       prevSoundEnabledRef.current = soundEnabled
       return
     }
@@ -80,18 +87,18 @@ const BackgroundNotifier = () => {
       if (soundEnabled) {
         const confirmed = isStatementConfirmed(comments)
         if (confirmed === null) {
-          neutralAudioFile.play()
+          playNotificationSound(neutralAudioFile, volume)
         } else if (confirmed) {
-          confirmAudioFile.play()
+          playNotificationSound(confirmAudioFile, volume)
         } else {
-          refuteAudioFile.play()
+          playNotificationSound(refuteAudioFile, volume)
         }
       }
     }
 
     // Always update the ref at the end
     prevFocusedStatementIdRef.current = focusedStatementId
-  }, [focusedStatementId, soundEnabled, comments, setFavicon])
+  }, [focusedStatementId, soundEnabled, comments, volume, setFavicon])
 
   return null
 }

--- a/app/components/App/BackgroundNotifier.jsx
+++ b/app/components/App/BackgroundNotifier.jsx
@@ -21,7 +21,13 @@ const setFavicon = (value) => {
 }
 
 const playNotificationSound = (audioFile, volume) => {
-  audioFile.volume = volume
+  const normalizedVolume = Math.min(Math.max(Number.isFinite(volume) ? volume : 1, 0), 1)
+
+  if (normalizedVolume === 0) {
+    return
+  }
+
+  audioFile.volume = normalizedVolume
   audioFile.play()
 }
 

--- a/app/components/VideoDebate/VideoDebatePlayer.jsx
+++ b/app/components/VideoDebate/VideoDebatePlayer.jsx
@@ -3,6 +3,14 @@ import ReactPlayer from 'react-player'
 
 import { useVideoPlayback } from '../../contexts/VideoPlaybackContext'
 
+const normalizeVolume = (volume) => {
+  if (!Number.isFinite(volume)) {
+    return null
+  }
+
+  return Math.min(Math.max(volume > 1 ? volume / 100 : volume, 0), 1)
+}
+
 const getNormalizedPlayerVolume = (player) => {
   const internalPlayer = player?.getInternalPlayer?.()
   if (!internalPlayer) {
@@ -10,14 +18,11 @@ const getNormalizedPlayerVolume = (player) => {
   }
 
   if (typeof internalPlayer.volume === 'number') {
-    return internalPlayer.volume
+    return normalizeVolume(internalPlayer.volume)
   }
 
   if (typeof internalPlayer.getVolume === 'function') {
-    const volume = internalPlayer.getVolume()
-    if (Number.isFinite(volume)) {
-      return volume > 1 ? volume / 100 : volume
-    }
+    return normalizeVolume(internalPlayer.getVolume())
   }
 
   return null
@@ -32,10 +37,12 @@ const VideoDebatePlayer = ({ url }) => {
   const playerRef = useRef(null)
   const prevForcedPositionRef = useRef(null)
   const cleanupVolumeListenerRef = useRef(null)
+  const lastSyncedVolumeRef = useRef(null)
 
   const updateVolumeFromPlayer = useCallback(() => {
     const volume = getNormalizedPlayerVolume(playerRef.current)
-    if (volume !== null) {
+    if (volume !== null && volume !== lastSyncedVolumeRef.current) {
+      lastSyncedVolumeRef.current = volume
       setVolume(volume)
     }
   }, [setVolume])

--- a/app/components/VideoDebate/VideoDebatePlayer.jsx
+++ b/app/components/VideoDebate/VideoDebatePlayer.jsx
@@ -1,16 +1,63 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import ReactPlayer from 'react-player'
 
 import { useVideoPlayback } from '../../contexts/VideoPlaybackContext'
+
+const getNormalizedPlayerVolume = (player) => {
+  const internalPlayer = player?.getInternalPlayer?.()
+  if (!internalPlayer) {
+    return null
+  }
+
+  if (typeof internalPlayer.volume === 'number') {
+    return internalPlayer.volume
+  }
+
+  if (typeof internalPlayer.getVolume === 'function') {
+    const volume = internalPlayer.getVolume()
+    if (Number.isFinite(volume)) {
+      return volume > 1 ? volume / 100 : volume
+    }
+  }
+
+  return null
+}
 
 /**
  * A player component with local state for position/playing.
  * Updates position when playing and seeks to position when requested.
  */
 const VideoDebatePlayer = ({ url }) => {
-  const { forcedPosition, isPlaying, setPosition, setPlaying } = useVideoPlayback()
+  const { forcedPosition, isPlaying, setPlaying, setPosition, setVolume } = useVideoPlayback()
   const playerRef = useRef(null)
   const prevForcedPositionRef = useRef(null)
+  const cleanupVolumeListenerRef = useRef(null)
+
+  const updateVolumeFromPlayer = useCallback(() => {
+    const volume = getNormalizedPlayerVolume(playerRef.current)
+    if (volume !== null) {
+      setVolume(volume)
+    }
+  }, [setVolume])
+
+  const attachVolumeListener = useCallback(() => {
+    cleanupVolumeListenerRef.current?.()
+
+    const internalPlayer = playerRef.current?.getInternalPlayer?.()
+    if (
+      typeof internalPlayer?.volume !== 'number' ||
+      typeof internalPlayer?.addEventListener !== 'function' ||
+      typeof internalPlayer?.removeEventListener !== 'function'
+    ) {
+      cleanupVolumeListenerRef.current = null
+      return
+    }
+
+    internalPlayer.addEventListener('volumechange', updateVolumeFromPlayer)
+    cleanupVolumeListenerRef.current = () => {
+      internalPlayer.removeEventListener('volumechange', updateVolumeFromPlayer)
+    }
+  }, [updateVolumeFromPlayer])
 
   useEffect(() => {
     if (
@@ -24,15 +71,35 @@ const VideoDebatePlayer = ({ url }) => {
     }
   }, [forcedPosition, setPlaying])
 
+  useEffect(() => {
+    return () => {
+      cleanupVolumeListenerRef.current?.()
+    }
+  }, [])
+
+  const handleReady = useCallback(() => {
+    updateVolumeFromPlayer()
+    attachVolumeListener()
+  }, [attachVolumeListener, updateVolumeFromPlayer])
+
+  const handleProgress = useCallback(
+    ({ playedSeconds }) => {
+      setPosition(playedSeconds)
+      updateVolumeFromPlayer()
+    },
+    [setPosition, updateVolumeFromPlayer],
+  )
+
   return (
     <ReactPlayer
       ref={playerRef}
       className="w-full aspect-video"
       url={url}
       playing={isPlaying}
+      onReady={handleReady}
       onPlay={() => setPlaying(true)}
       onPause={() => setPlaying(false)}
-      onProgress={({ playedSeconds }) => setPosition(playedSeconds)}
+      onProgress={handleProgress}
       width=""
       height=""
       controls

--- a/app/contexts/VideoPlaybackContext.jsx
+++ b/app/contexts/VideoPlaybackContext.jsx
@@ -3,6 +3,7 @@ import React, { createContext, useCallback, useContext, useMemo, useReducer, use
 const initialState = {
   position: 0,
   isPlaying: false,
+  volume: 1,
   forcedPosition: { requestId: null, time: 0 },
 }
 
@@ -17,6 +18,11 @@ const playbackReducer = (state, action) => {
       return {
         ...state,
         isPlaying: action.payload,
+      }
+    case 'SET_VOLUME':
+      return {
+        ...state,
+        volume: action.payload,
       }
     case 'FORCE_POSITION':
       return {
@@ -56,6 +62,11 @@ export const VideoPlaybackProvider = ({ children, onUpdatePosition }) => {
     dispatch({ type: 'SET_PLAYING', payload: isPlaying })
   }, [])
 
+  const setVolume = useCallback((volume) => {
+    const normalizedVolume = Math.min(Math.max(volume, 0), 1)
+    dispatch({ type: 'SET_VOLUME', payload: normalizedVolume })
+  }, [])
+
   const forcePosition = useCallback((time) => {
     dispatch({ type: 'FORCE_POSITION', payload: time })
   }, [])
@@ -64,12 +75,23 @@ export const VideoPlaybackProvider = ({ children, onUpdatePosition }) => {
     () => ({
       position: state.position,
       isPlaying: state.isPlaying,
+      volume: state.volume,
       forcedPosition: state.forcedPosition,
       setPosition,
       setPlaying,
+      setVolume,
       forcePosition,
     }),
-    [state.position, state.isPlaying, state.forcedPosition, setPosition, setPlaying, forcePosition],
+    [
+      state.position,
+      state.isPlaying,
+      state.volume,
+      state.forcedPosition,
+      setPosition,
+      setPlaying,
+      setVolume,
+      forcePosition,
+    ],
   )
 
   return <VideoPlaybackContext.Provider value={value}>{children}</VideoPlaybackContext.Provider>


### PR DESCRIPTION
## Summary
- Track ReactPlayer volume in `VideoPlaybackContext`, normalized to the 0..1 range used by `HTMLAudioElement.volume`.
- Update the stored volume from ReactPlayer on ready/progress and from DOM `volumechange` events when available.
- Apply the current video volume before confirm/refute/neutral background notification sounds play.

Fixes CaptainFact/captain-fact#93

## Validation
- `npm run typescript`
- `.\node_modules\.bin\eslint.cmd --quiet app\components\App\BackgroundNotifier.jsx app\components\VideoDebate\VideoDebatePlayer.jsx app\contexts\VideoPlaybackContext.jsx`
- `.\node_modules\.bin\prettier.cmd --check app\components\App\BackgroundNotifier.jsx app\components\VideoDebate\VideoDebatePlayer.jsx app\contexts\VideoPlaybackContext.jsx`
- `git diff --check -- app\contexts\VideoPlaybackContext.jsx app\components\VideoDebate\VideoDebatePlayer.jsx app\components\App\BackgroundNotifier.jsx`
- `npm run build`