### PR TITLE
Fix: Sync background notification volume with video player

### DIFF
--- a/app/components/App/BackgroundNotifier.jsx
+++ b/app/components/App/BackgroundNotifier.jsx
@@ -6,6 +6,7 @@ import neutralSoundFileURL from '../../assets/sounds/background_statement_neutra
 import refuteSoundFileURL from '../../assets/sounds/background_statement_refute.mp3'
 import { useFocusedStatement } from '../../contexts/FocusedStatementContext'
 import { useUserPreferences } from '../../contexts/UserPreferencesContext'
+import { useVideoPlayback } from '../../contexts/VideoPlaybackContext'
 import { isStatementConfirmed } from '../../lib/statements_utils'
 
 const confirmAudioFile = new Audio(confirmSoundFileURL)
@@ -27,6 +28,7 @@ const setFavicon = (value) => {
 const BackgroundNotifier = () => {
   const { statement } = useFocusedStatement()
   const { enableSoundOnBackgroundFocus: soundEnabled } = useUserPreferences()
+  const { volume } = useVideoPlayback()
   const prevFocusedStatementIdRef = useRef(-1)
   const prevSoundEnabledRef = useRef(soundEnabled)
 
@@ -57,6 +59,11 @@ const BackgroundNotifier = () => {
 
   // Handle sound enable/disable and statement focus changes
   useEffect(() => {
+    // Update audio volumes
+    confirmAudioFile.volume = volume
+    refuteAudioFile.volume = volume
+    neutralAudioFile.volume = volume
+
     // Play a sound when enabling setting
     if (!prevSoundEnabledRef.current && soundEnabled) {
       neutralAudioFile.play()
@@ -91,7 +98,7 @@ const BackgroundNotifier = () => {
 
     // Always update the ref at the end
     prevFocusedStatementIdRef.current = focusedStatementId
-  }, [focusedStatementId, soundEnabled, comments, setFavicon])
+  }, [focusedStatementId, soundEnabled, comments, setFavicon, volume])
 
   return null
 }

--- a/app/components/VideoDebate/VideoDebatePlayer.jsx
+++ b/app/components/VideoDebate/VideoDebatePlayer.jsx
@@ -8,7 +8,7 @@ import { useVideoPlayback } from '../../contexts/VideoPlaybackContext'
  * Updates position when playing and seeks to position when requested.
  */
 const VideoDebatePlayer = ({ url }) => {
-  const { forcedPosition, isPlaying, setPosition, setPlaying } = useVideoPlayback()
+  const { forcedPosition, isPlaying, setPosition, setPlaying, setVolume } = useVideoPlayback()
   const playerRef = useRef(null)
   const prevForcedPositionRef = useRef(null)
 
@@ -33,6 +33,7 @@ const VideoDebatePlayer = ({ url }) => {
       onPlay={() => setPlaying(true)}
       onPause={() => setPlaying(false)}
       onProgress={({ playedSeconds }) => setPosition(playedSeconds)}
+      onVolumeChange={(volume) => setVolume(volume)}
       width=""
       height=""
       controls

--- a/app/contexts/VideoPlaybackContext.jsx
+++ b/app/contexts/VideoPlaybackContext.jsx
@@ -4,6 +4,7 @@ const initialState = {
   position: 0,
   isPlaying: false,
   forcedPosition: { requestId: null, time: 0 },
+  volume: 1.0,
 }
 
 const playbackReducer = (state, action) => {
@@ -22,6 +23,11 @@ const playbackReducer = (state, action) => {
       return {
         ...state,
         forcedPosition: { requestId: Date.now(), time: action.payload },
+      }
+    case 'SET_VOLUME':
+      return {
+        ...state,
+        volume: action.payload,
       }
     default:
       return state
@@ -60,16 +66,22 @@ export const VideoPlaybackProvider = ({ children, onUpdatePosition }) => {
     dispatch({ type: 'FORCE_POSITION', payload: time })
   }, [])
 
+  const setVolume = useCallback((volume) => {
+    dispatch({ type: 'SET_VOLUME', payload: volume })
+  }, [])
+
   const value = useMemo(
     () => ({
       position: state.position,
       isPlaying: state.isPlaying,
       forcedPosition: state.forcedPosition,
+      volume: state.volume,
       setPosition,
       setPlaying,
       forcePosition,
+      setVolume,
     }),
-    [state.position, state.isPlaying, state.forcedPosition, setPosition, setPlaying, forcePosition],
+    [state.position, state.isPlaying, state.forcedPosition, state.volume, setPosition, setPlaying, forcePosition, setVolume],
   )
 
   return <VideoPlaybackContext.Provider value={value}>{children}</VideoPlaybackContext.Provider>


### PR DESCRIPTION
Fixes CaptainFact/captain-fact#93

## Summary
- Added `volume` state to `VideoPlaybackContext`
- Passed `onVolumeChange` from `ReactPlayer` to update the context volume using the direct numeric argument (avoids the `event.target.volume` undefined bug )
- Applied the context volume to the `Audio` elements in `BackgroundNotifier` before playback

This ensures background notifications scale with the user's video volume — no more loud notifications when the video is quiet.
